### PR TITLE
docs: update all documentation for v4.0.0 API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   - **`AsyncConfiguredEnvironment`**: An environment managing the provisioning of a global configuration from configuration infrastructures.
   - **`WebApplication`** is now automatically provided with configuration by the `AsyncWebEnvironment`.
 
-For more information, see the [Advanced Functionalities - Configuration](./README.md#configuration) and [Advanced Functionalities - Web](./README.md#web).
+For more information, see the [Advanced Features - Configuration](./Documentation/3-advanced-features.md#configuration) and [Advanced Features - Web Testing](./Documentation/3-advanced-features.md#web-testing).
 
 ## v2.1.0
 
@@ -18,7 +18,7 @@ For more information, see the [Advanced Functionalities - Configuration](./READM
 
 - Added the `AutoReset` property to toggle infrastructure reset on or off.
 
-For more information, see the [Advanced Functionalities - Advanced control over Infrastructure Reset](./README.md#advanced-control-over-infrastructure-resets)
+For more information, see the [Advanced Features - Disabling automatic reset](./Documentation/3-advanced-features.md#disabling-automatic-reset)
 
 ## v2.2.0
 
@@ -46,10 +46,10 @@ For more information, see the [Advanced Functionalities - Advanced control over 
 
 - **NotoriousTest.TestContainers** is now available as a separate package.
   - Provides a simple way to use TestContainers in your tests.
-  - For more information, see the [Advanced Functionalities - TestContainers](./README.md#testcontainers).
+  - For more information, see the [Integrations - TestContainers](./Documentation/4-integrations.md#testcontainers).
 - **NotoriousTest.SqlServer** is now available as a separate package.
-  - Provide your tests with a SqlServer ready-to-use infrastructure !
-  - For more information, see the [Advanced Functionalities - SqlServer](./README.md#sql-server).
+  - Provide your tests with a SqlServer ready-to-use infrastructure!
+  - For more information, see the [Integrations - SQL Server](./Documentation/4-integrations.md#sql-server-docker).
 
 ### 🛠 Technical
 
@@ -101,7 +101,7 @@ For more information, see the [Advanced Functionalities - Advanced control over 
 
 #### Settings 💥NEW💥
 - By registering a `SettingsExtension`, you can now load settings from `testsettings.json` to configure infrastructure.
-git stash- Automatically loaded from the infrastructure name as config key.
+- Automatically loaded from the infrastructure name as config key.
 
 #### Output configuration 🔧 UPDATED 🔧
 - Environments no longer require a global configuration object. Configuration is now propagated automatically through extensions.

--- a/Documentation/2-core-concepts.md
+++ b/Documentation/2-core-concepts.md
@@ -1,18 +1,21 @@
 # 🏗️ Core Concepts
 
-NotoriousTest provides a structured way to manage **test infrastructures** and ensure **clean, isolated integration tests**.  
+NotoriousTest provides a structured way to manage **test infrastructures** and ensure **clean, isolated integration tests**.
 This document introduces the core concepts and how they work together.
 
 ## 🏗️ What is an Infrastructure?
 
-An **infrastructure** represents an external dependency required for testing.  
+An **infrastructure** represents an external dependency required for testing.
 This could be a **database, message queue, file storage, API client**, or any service that needs to be set up and managed during tests.
 
 ### ✨ **Example of an Infrastructure**
 
 ```csharp
-public class MyInfrastructure : AsyncInfrastructure
+public class MyInfrastructure : Infrastructure
 {
+    public MyInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
+
     public override Task Initialize()
     {
         // Setup logic here (e.g., start a database, configure an API)
@@ -37,7 +40,9 @@ public class MyInfrastructure : AsyncInfrastructure
 
 - `Initialize()` → Called once at the start of the test session.
 - `Reset()` → Called before each test to ensure data isolation.
-- `Destroy()` → Called at the end of the test session to clean up resources
+- `Destroy()` → Called at the end of the test session to clean up resources.
+
+> Infrastructures are resolved through dependency injection. Use `AddInfrastructure<T>()` in your environment — the framework will inject `EnvironmentId`, `ITestLogger`, and `IRegistry` automatically.
 
 ## 🌍 What is a Test Environment?
 
@@ -47,13 +52,16 @@ Instead of manually initializing infrastructures in every test, you define them 
 ✨ **Example of a Test Environment**
 
 ```csharp
-public class MyTestEnvironment : AsyncEnvironment
+public class MyTestEnvironment : NotoriousTest.XUnit.Environment
 {
-    public override async Task ConfigureEnvironmentAsync()
+    public MyTestEnvironment(IMessageSink sink) : base(sink) { }
+    public override Assembly CurrentAssembly => Assembly.GetExecutingAssembly();
+
+    public override async Task ConfigureEnvironment()
     {
-        // Register infrastructures
-        AddInfrastructure(new MyInfrastructure());
-        AddInfrastructure(new MyInfrastructure2());
+        // Register infrastructures via DI
+        AddInfrastructure<MyInfrastructure>();
+        AddInfrastructure<MyInfrastructure2>();
     }
 }
 ```
@@ -63,22 +71,23 @@ public class MyTestEnvironment : AsyncEnvironment
 - Environments encapsulate multiple infrastructures.
 - They ensure consistency across all tests.
 - They handle initialization, reset, and cleanup automatically.
+- `IMessageSink` is injected by xUnit and used for test output/logging.
 
 ## 🔄 How Does the Test Lifecycle Work?
 
 NotoriousTest manages your test lifecycle automatically to ensure clean and isolated tests.
 
 **Test Session Starts** \
-Infrastructures are initialized (Initialize()).
+Infrastructures are initialized (`Initialize()`).
 
 **Before Each Test** \
-Infrastructures are reset (Reset()).
+Infrastructures are reset (`Reset()`).
 
 **Test Runs** \
 The test executes in an isolated environment.
 
 **After Test Suite Completes** \
-Infrastructures are destroyed (Destroy()).
+Infrastructures are destroyed (`Destroy()`).
 
 🔥 **Why is this important?** \
 ✅ Guarantees clean data for each test (no unwanted side effects). \
@@ -92,7 +101,6 @@ Once a test environment is configured, you can retrieve any registered infrastru
 **✨ Example Test with an Infrastructure**
 
 ```csharp
-
 public class MyIntegrationTests : IntegrationTest<MyTestEnvironment>
 {
     public MyIntegrationTests(MyTestEnvironment environment) : base(environment) { }
@@ -101,7 +109,7 @@ public class MyIntegrationTests : IntegrationTest<MyTestEnvironment>
     public async Task ExampleTest()
     {
         // Retrieve the infrastructure from the environment
-        var infra = await CurrentEnvironment.GetInfrastructureAsync<MyInfrastructure>();
+        var infra = CurrentEnvironment.GetInfrastructure<MyInfrastructure>();
 
         // Use the infrastructure
         Assert.NotNull(infra); // Example check
@@ -111,7 +119,7 @@ public class MyIntegrationTests : IntegrationTest<MyTestEnvironment>
 
 📌 **Key Takeaways:**
 
-- GetInfrastructureAsync<T>() → Retrieves an infrastructure inside a test.
+- `GetInfrastructure<T>()` → Retrieves an infrastructure inside a test.
 - No need for manual setup inside test classes.
 - Tests remain clean and focused on logic instead of infrastructure handling.
 
@@ -121,7 +129,7 @@ public class MyIntegrationTests : IntegrationTest<MyTestEnvironment>
 | Infrastructure | Represents an external dependency (DB, API, Queue). |
 | Test Environment | Groups infrastructures together for consistent tests.|
 | Lifecycle | Ensures clean initialization, reset before tests, and proper cleanup.|
-| Retrieving Infra | Use GetInfrastructureAsync<T>() inside tests. |
+| Retrieving Infra | Use `GetInfrastructure<T>()` inside tests. |
 
 Now that you understand the fundamentals, check out:
 

--- a/Documentation/3-advanced-features.md
+++ b/Documentation/3-advanced-features.md
@@ -1,7 +1,10 @@
-## Advanced functionalities
+## Advanced Functionalities
 
 - [Configuration](#configuration)
 - [Web Testing](#web-testing)
+- [Extensions](#extensions)
+- [Dependency Injection](#dependency-injection)
+- [Logging](#logging)
 - [Miscellaneous](#miscellaneous)
 
 ### Configuration
@@ -14,17 +17,20 @@ Each infrastructure can produce a list of `ConfigurationEntry<T>`, where `T` is 
 
 #### Producing configuration
 
-To produce configuration, call `AddOutputConfigurationEntry` inside `Initialize()`.
+To produce configuration, inherit from `Infrastructure<TOutputConfiguration, TMetadata>` and call `AddEntry(key, value)` inside `Initialize()`.
 The key will be used by the consumer to determine where to place this section of the config.
 e.g. `WebApplication` uses it as a path for appsettings replacement (`Key:Key:Key`).
 
 ```csharp
-public class SqlServerInfrastructure : Infrastructure<LanaeDatabase>
+public class SqlServerInfrastructure : Infrastructure<LanaeDatabase, object>
 {
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
+
     public override async Task Initialize()
     {
         // Start your container, get the connection string...
-        AddOutputConfigurationEntry("Databases:Lanae", new LanaeDatabase
+        AddEntry("Databases:Lanae", new LanaeDatabase
         {
             ConnectionString = "Server=localhost;..."
         });
@@ -35,15 +41,21 @@ public class SqlServerInfrastructure : Infrastructure<LanaeDatabase>
 }
 ```
 
-If you don't need a typed object, `Infrastructure` (without generic) accepts `object` directly:
+If you don't need a typed output, use `Infrastructure<string, object>` and pass a plain string value:
 
 ```csharp
-public class RedisInfrastructure : Infrastructure
+public class RedisInfrastructure : Infrastructure<string, object>
 {
+    public RedisInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
+
     public override async Task Initialize()
     {
-        AddOutputConfigurationEntry("Cache:Redis:Host", "localhost");
+        AddEntry("Cache:Redis:Host", "localhost");
     }
+
+    public override Task Reset() => Task.CompletedTask;
+    public override Task Destroy() => Task.CompletedTask;
 }
 ```
 
@@ -54,6 +66,9 @@ An infrastructure can consume the configuration produced by previously initializ
 ```csharp
 public class MyInfrastructure : Infrastructure, IConfigurationConsumer
 {
+    public MyInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
+
     public List<ConfigurationEntry<object>> ConsumedConfiguration { get; set; } = new();
 
     public override Task Initialize()
@@ -64,6 +79,9 @@ public class MyInfrastructure : Infrastructure, IConfigurationConsumer
         // Use redisHost...
         return Task.CompletedTask;
     }
+
+    public override Task Reset() => Task.CompletedTask;
+    public override Task Destroy() => Task.CompletedTask;
 }
 ```
 
@@ -84,13 +102,16 @@ internal class SampleProjectApp : WebApplication<Program> { }
 #### Web Environment
 
 ```csharp
-public class SampleEnvironment : AsyncWebEnvironment
+public class SampleEnvironment : NotoriousTest.XUnit.Environment
 {
-    public override Task ConfigureEnvironmentAsync()
+    public SampleEnvironment(IMessageSink sink) : base(sink) { }
+    public override Assembly CurrentAssembly => Assembly.GetExecutingAssembly();
+
+    public override Task ConfigureEnvironment()
     {
-        AddInfrastructure(new SqlServerInfrastructure());
-        AddInfrastructure(new RedisInfrastructure());
-        AddWebApplication(new SampleProjectApp());
+        AddInfrastructure<SqlServerInfrastructure>();
+        AddInfrastructure<RedisInfrastructure>();
+        this.AddWebApplication<SampleProjectApp>();
 
         return Task.CompletedTask;
     }
@@ -99,18 +120,127 @@ public class SampleEnvironment : AsyncWebEnvironment
 
 The `WebApplication` is always initialized last — it depends on the configuration produced by all other infrastructures.
 
-In your tests, access the `HttpClient` via `GetWebApplication`:
+In your tests, access the `HttpClient` via `GetWebApplication()`:
 
 ```csharp
 [Fact]
 public async Task ShouldReturnWeather()
 {
-    HttpClient client = (await CurrentEnvironment.GetWebApplication()).HttpClient!;
+    HttpClient client = CurrentEnvironment.GetWebApplication().HttpClient!;
 
     HttpResponseMessage response = await client.GetAsync("api/weather");
     Assert.True(response.IsSuccessStatusCode);
 }
 ```
+
+### Extensions
+
+Extensions let you hook into the infrastructure lifecycle without modifying the infrastructure itself. They implement `IInfrastructureExtension` and respond to events like `OnBeforeInitialize`, `OnAfterInitialize`, `OnBeforeReset`, etc.
+
+#### Registering an extension
+
+```csharp
+public class MyInfrastructure : Infrastructure
+{
+    public MyInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry)
+    {
+        EnsureExtension<MyCustomExtension>();
+        // or with an instance:
+        EnsureExtension(new MyCustomExtension());
+    }
+}
+```
+
+#### Built-in extensions
+
+**`OutputConfigurationExtension<T>`** — used internally by `Infrastructure<TOutputConfiguration, TMetadata>` to produce configuration entries. You rarely need to use this directly.
+
+**`SettingsExtension<TSettings>`** — loads settings from `testsettings.json` and exposes them via `extension.Settings`. The section name defaults to the infrastructure's class name.
+
+```csharp
+public class MySettings
+{
+    public string ConnectionString { get; set; }
+}
+
+public class MyInfrastructure : Infrastructure
+{
+    private SettingsExtension<MySettings> _settings;
+
+    public MyInfrastructure(EnvironmentId contextId, ITestSettingsProvider settingsProvider, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry)
+    {
+        _settings = EnsureExtension(new SettingsExtension<MySettings>(settingsProvider));
+    }
+
+    public override Task Initialize()
+    {
+        var connectionString = _settings.Settings.ConnectionString;
+        // use connection string...
+        return Task.CompletedTask;
+    }
+}
+```
+
+**`RespawnExtension`** (from `NotoriousTest.Database`) — resets the database before each test using [Respawn](https://github.com/jbogard/Respawn). Used automatically by `SqlServerContainerInfrastructure` and `PostgreContainerInfrastructure`.
+
+```csharp
+EnsureExtension(new RespawnExtension(() => new RespawnerOptions
+{
+    TablesToIgnore = new Table[] { "Migrations" }
+}));
+```
+
+### Dependency Injection
+
+You can register services that will be injected into your infrastructures. Override `ConfigureInfrastructureServices` in your environment:
+
+```csharp
+public class SampleEnvironment : NotoriousTest.XUnit.Environment
+{
+    public SampleEnvironment(IMessageSink sink) : base(sink) { }
+    public override Assembly CurrentAssembly => Assembly.GetExecutingAssembly();
+
+    public override void ConfigureInfrastructureServices(IServiceCollection collection)
+    {
+        base.ConfigureInfrastructureServices(collection);
+        collection.AddSingleton<IMyService, MyService>();
+    }
+
+    public override Task ConfigureEnvironment()
+    {
+        AddInfrastructure<MyInfrastructure>();
+        return Task.CompletedTask;
+    }
+}
+```
+
+Infrastructure constructors will receive registered services automatically via `ActivatorUtilities`.
+
+### Logging
+
+Every infrastructure receives an `ITestLogger` via its constructor, accessible through the `Logger` property. Messages are forwarded to xUnit's output system.
+
+Enable diagnostic messages in `xunit.runner.json`:
+
+```json
+{
+  "diagnosticMessages": true
+}
+```
+
+Then use `Logger` inside your infrastructure:
+
+```csharp
+public override async Task Initialize()
+{
+    Logger.Log("Starting my infrastructure...");
+    // ...
+}
+```
+
+Log output appears in Visual Studio's test output window or the terminal when running `dotnet test`.
 
 ### Miscellaneous
 
@@ -125,21 +255,38 @@ public class SqlServerInfrastructure : Infrastructure
 }
 ```
 
-Infrastructures without an `Order` are executed first by default. `WebApplicationInfrastructure` is always executed last.
+Infrastructures without an `Order` are executed first by default. `WebApplicationInfrastructure` is always executed last (order 999).
 
 #### Disabling automatic reset
 
 By default, all infrastructures are reset between each test. You can disable this per infrastructure:
 
 ```csharp
-public class SampleEnvironment : AsyncWebEnvironment
+public class SampleEnvironment : NotoriousTest.XUnit.Environment
 {
-    public override Task ConfigureEnvironmentAsync()
+    public SampleEnvironment(IMessageSink sink) : base(sink) { }
+    public override Assembly CurrentAssembly => Assembly.GetExecutingAssembly();
+
+    public override Task ConfigureEnvironment()
     {
-        AddInfrastructure(new SqlServerInfrastructure { AutoReset = false });
-        AddWebApplication(new SampleProjectApp());
+        AddInfrastructure<SqlServerInfrastructure>();
+        GetInfrastructure<SqlServerInfrastructure>().AutoReset = false;
+        this.AddWebApplication<SampleProjectApp>();
 
         return Task.CompletedTask;
+    }
+}
+```
+
+Alternatively, set `AutoReset` directly in the infrastructure constructor:
+
+```csharp
+public class MyInfrastructure : Infrastructure
+{
+    public MyInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry)
+    {
+        AutoReset = false;
     }
 }
 ```

--- a/Documentation/4-integrations.md
+++ b/Documentation/4-integrations.md
@@ -1,349 +1,366 @@
 ## Integrations
 
 - [TestContainers](#testcontainers)
-- [SqlServer](#sql-server)
+- [SQL Server (Docker)](#sql-server-docker)
+- [SQL Server (External)](#sql-server-external)
+- [PostgreSQL (Docker)](#postgresql-docker)
+- [PostgreSQL (External)](#postgresql-external)
 
 ### TestContainers
 
-**NotoriousTest.TestContainers** is now available as a separate package.
-
-Install [NotoriousTest](https://www.nuget.org/packages/NotoriousTest/) from the package manager console:
+**NotoriousTest.TestContainers** is available as a separate package.
 
 ```
 PM> Install-Package NotoriousTest.TestContainers
 ```
 
-Or from the .NET CLI as:
+Or from the .NET CLI:
 
 ```
 dotnet add package NotoriousTest.TestContainers
 ```
 
-This package provides an infrastructure that automatically start and stop the container at the beginning and end of the test campaign!
-Simply inherit from **`DockerContainerInfrastructure<TContainer>`**.
+This package provides a base infrastructure that automatically starts and stops any TestContainers container at the beginning and end of the test campaign.
 
-> ❗ Since `TestContainers` doesn't support synchronous code, theses classes are only available in an `AsyncEnvironment`.
-
-Here's an example :
+Inherit from `DockerContainerInfrastructure<TContainer, TOutputConfiguration>`:
 
 ```csharp
-public class SqlServerContainerInfrastructure : DockerContainerInfrastructure<MsSqlContainer>
+public class MyContainerInfrastructure : DockerContainerInfrastructure<MsSqlContainer, string>
 {
-    public override MsSqlContainer Container {get; init;} = new MsSqlBuild().Build();
-
-    public SampleDockerContainer(bool initialize = false) : base(initialize)
+    public MyContainerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry)
     {
+        Container = new MsSqlBuilder().Build();
     }
 
-    public override Task Reset()
-    {
-        return Task.CompletedTask;
-    }
+    public override Task Reset() => Task.CompletedTask;
 }
 ```
 
-### Sql Server
+> ❗ Use `string` as the `TOutputConfiguration` type parameter if your infrastructure does not produce configuration, or use a custom type if it does.
 
-#### Initialization
+---
 
-**NotoriousTest.SqlServer** is now available as a separate package.
+### SQL Server (Docker)
 
-Install [NotoriousTest.SqlServer](https://www.nuget.org/packages/NotoriousTest.SqlServer/) from the package manager console:
+**NotoriousTest.SqlServer** is available as a separate package.
 
 ```
 PM> Install-Package NotoriousTest.SqlServer
 ```
 
-Or from the .NET CLI as:
+Or from the .NET CLI:
 
 ```
 dotnet add package NotoriousTest.SqlServer
 ```
 
-You can now simply use the SqlServerContainerAsyncInfrastructure to start a SQL Server database.
+#### Initialization
 
-It will automatically start at the beginning of the test campaign, stop at the end, and reset between each test, powered by TestContainers and Respawn.
+Inherit from `SqlServerContainerInfrastructure` to get a containerized SQL Server database that:
 
-Here's an example:
+- **On initialization:** starts a SQL Server Docker container (via TestContainers) and creates a unique database.
+- **On reset:** empties the database (via Respawn).
+- **On destruction:** stops and removes the container.
 
 ```csharp
-   public class SqlServerInfrastructure : SqlServerContainerInfrastructure
-    {
-        public SqlServerInfrastructure()
-        {
-        }
-    }
+public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+{
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
+}
 ```
 
-This infrastructure performs several tasks:
-
-- **On initialization:**
-  - Starts a SQL Server Docker container, powered by TestContainers.
-  - Creates a unique database.
-- **On reset:**
-  - Empties the database, powered by Respawn.
-- **On destruction:**
-  - Stops the container.
-
-#### Test Usage
-
-The infrastructure provides two methods:
-
-- **`GetDatabaseConnection`** – Returns a `SqlConnection` pointing to the newly created database for your test.
-- **`GetDatabaseConnectionString`** – Returns a connection string pointing to the newly created database for your test.
+#### Test usage
 
 ```csharp
 [Fact]
 public async Task Test1()
 {
-    SqlServerInfrastructure sqlInfrastructure = await CurrentEnvironment.GetInfrastructure<SqlServerInfrastructure>();
-    await using(SqlConnection sql = sqlInfrastructure.GetDatabaseConnection())
+    SqlServerInfrastructure sqlInfrastructure = CurrentEnvironment.GetInfrastructure<SqlServerInfrastructure>();
+    await using (DbConnection sql = sqlInfrastructure.GetDatabaseConnection())
     {
+        await sql.OpenAsync();
         // Arrange your database here.
     }
 }
 ```
 
+- **`GetDatabaseConnection()`** — returns a `DbConnection` (SqlConnection) pointing to the newly created database.
+- **`GetDatabaseConnectionString()`** — returns the connection string for the newly created database.
+
 #### Populating the database
 
-You can populate the database by overriding the `PopulateDatabase` method :
+Override `Initialize()` and call `base.Initialize()` first, then open the database connection and run your schema setup:
 
 ```csharp
-   public class SqlServerInfrastructure : SqlServerContainerInfrastructure
-    {
-        public SqlServerInfrastructure()
-        {
-        }
+public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+{
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
 
-        protected override async Task PopulateDatabase(SqlConnection connection)
-        {
-            // Play all your migrations script here, use DBUp or any other migration tool
-            await CreateTables(connection);
-        }
+    public override async Task Initialize()
+    {
+        await base.Initialize();
+
+        await using var connection = GetDatabaseConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = @"CREATE TABLE Users (
+            user_id INT IDENTITY(1,1) PRIMARY KEY,
+            username NVARCHAR(50) NOT NULL UNIQUE
+        );";
+        await command.ExecuteNonQueryAsync();
     }
+}
 ```
 
-#### Generating configuration
+#### Generating configuration for the web app
 
-You can generate configuration for your web application by overriding the `Initialize` method :
+Override the `ConnectionStringKey` property to control which appsettings key the connection string is published under.
+By default, the key is `ConnectionStrings:Default`.
 
 ```csharp
-   public class SqlServerInfrastructure : SqlServerContainerInfrastructure, IConfigurable
-    {
-        public SqlServerInfrastructure()
-        {
-        }
+public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+{
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
 
-        public override async Task Initialize()
-        {
-            await base.Initialize();
-            // We can add the connection string to the configuration.
-            Configuration.Add("ConnectionStrings:SqlServer", GetDatabaseConnectionString());
-        }
-    }
+    protected override string ConnectionStringKey => "ConnectionStrings:SqlServer";
+}
 ```
+
+The connection string is automatically published to `WebApplication` under this key.
 
 #### Configure the container
 
-You can configure the container by overriding the `ConfigureSqlContainer` method :
+Override `ConfigureSqlContainer` to customise the MsSql container:
 
 ```csharp
-   public class SqlServerInfrastructure : SqlServerContainerInfrastructure
-    {
-        public SqlServerInfrastructure()
-        {
-        }
+public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+{
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
 
-        protected override MsSqlBuilder ConfigureSqlContainer(MsSqlBuilder builder)
-        {
-            // Configure the builder to override image, host, password, port, etc.
-            return builder.WithPassword("NotoriousStrong(!)Password6");
-        }
+    protected override MsSqlBuilder ConfigureSqlContainer(MsSqlBuilder builder)
+    {
+        return builder.WithPassword("NotoriousStrong(!)Password6");
     }
+}
 ```
 
-#### Configure respawn settings
+#### Configuring Respawn (table filtering)
 
-To configure respawn settings, you can assign RespawnOptions property. They will be used by respawn to reset the database.
+Use the `TableToIgnore`, `TableToInclude`, `SchemasToInclude`, and `SchemasToExclude` init properties to control which tables Respawn resets:
 
 ```csharp
-   public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+{
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry)
     {
-        public SqlServerInfrastructure()
-        {
-            RespawnOptions = new RespawnerOptions
-            {
-                TablesToIgnore = new Table[] { "MyMigrationTable" }
-            };
-        }
+        TableToIgnore = ["Migrations"];
     }
+}
 ```
 
-#### Configure the database name
+#### Configure the database name prefix
 
-By default, Database name will be `NotoriousDb` concatened with the `ContextId`.
-You can override `NotoriousDb` by your custom name by setting the property `DbName`.
+By default, the database name is `NotoriousDb_{EnvironmentId}`.
+Override `DbPrefix` to customise the prefix:
 
 ```csharp
-   public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+{
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry)
     {
-        public SqlServerInfrastructure()
-        {
-            DbName = "TestDb";
-        }
+        DbPrefix = "TestDb";
     }
+}
 ```
 
+---
 
-### PostgreSQL
+### SQL Server (External)
 
-#### Initialization
+For scenarios where a SQL Server instance is already running (e.g. a local or CI server), use `SqlServerInfrastructure` (from `NotoriousTest.SqlServer`).
 
-**NotoriousTest.PostgreSql** is now available as a separate package.
+Connection settings are loaded from `testsettings.json`:
 
-Install [NotoriousTest.PostgreSql](https://www.nuget.org/packages/NotoriousTest.PostgreSql/) from the package manager console:
+```json
+{
+  "SqlServerInfrastructure": {
+    "ConnectionString": "Server=localhost;User Id=sa;Password=yourPassword;TrustServerCertificate=True;"
+  }
+}
+```
+
+```csharp
+public class SqlServerInfrastructure : SqlServerInfrastructure
+{
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestSettingsProvider settingsProvider, ITestLogger logger, IRegistry registry)
+        : base(contextId, settingsProvider, logger, registry) { }
+
+    protected override string ConnectionStringKey => "ConnectionStrings:SqlServer";
+}
+```
+
+The behavior is identical to the Docker version (creates/drops a unique database, resets via Respawn), but no container is started.
+
+---
+
+### PostgreSQL (Docker)
+
+**NotoriousTest.PostgreSql** is available as a separate package.
 
 ```
 PM> Install-Package NotoriousTest.PostgreSql
 ```
 
-Or from the .NET CLI as:
+Or from the .NET CLI:
 
 ```
 dotnet add package NotoriousTest.PostgreSql
 ```
 
-You can now simply use the PostgreContainerInfrastructure to start a Postgre database.
+#### Initialization
 
-It will automatically start at the beginning of the test campaign, stop at the end, and reset between each test, powered by TestContainers and Respawn.
+Inherit from `PostgreContainerInfrastructure` to get a containerized PostgreSQL database that:
 
-Here's an example:
+- **On initialization:** starts a PostgreSQL Docker container (via TestContainers) and creates a unique database.
+- **On reset:** empties the database (via Respawn).
+- **On destruction:** stops and removes the container.
 
 ```csharp
-   public class PostgreSqlInfrastructure : PostgreContainerInfrastructure
-    {
-        public PostgreSqlInfrastructure()
-        {
-        }
-    }
+public class PostgreSqlInfrastructure : PostgreContainerInfrastructure
+{
+    public PostgreSqlInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
+}
 ```
 
-This infrastructure performs several tasks:
-
-- **On initialization:**
-  - Starts a PostgreSql Docker container, powered by TestContainers.
-  - Creates a unique database.
-- **On reset:**
-  - Empties the database, powered by Respawn.
-- **On destruction:**
-  - Stops the container.
-
-#### Test Usage
-
-The infrastructure provides two methods:
-
-- **`GetDatabaseConnection`** – Returns a `NpgsqlConnection` pointing to the newly created database for your test.
-- **`GetDatabaseConnectionString`** – Returns a connection string pointing to the newly created database for your test.
+#### Test usage
 
 ```csharp
 [Fact]
 public async Task Test1()
 {
-    PostgreSqlInfrastructure postgreInfrastructure = await CurrentEnvironment.GetInfrastructure<PostgreSqlInfrastructure>();
-    await using(NpgsqlConnection sql = postgreInfrastructure.GetDatabaseConnection())
+    PostgreSqlInfrastructure postgreInfrastructure = CurrentEnvironment.GetInfrastructure<PostgreSqlInfrastructure>();
+    await using (DbConnection sql = postgreInfrastructure.GetDatabaseConnection())
     {
+        await sql.OpenAsync();
         // Arrange your database here.
     }
 }
 ```
 
+- **`GetDatabaseConnection()`** — returns a `DbConnection` (NpgsqlConnection) pointing to the newly created database.
+- **`GetDatabaseConnectionString()`** — returns the connection string for the newly created database.
+
 #### Populating the database
 
-You can populate the database by overriding the `PopulateDatabase` method :
-
 ```csharp
-   public class PostgreSqlInfrastructure : PostgreContainerAsyncInfrastructure
-    {
-        public PostgreSqlInfrastructure()
-        {
-        }
+public class PostgreSqlInfrastructure : PostgreContainerInfrastructure
+{
+    public PostgreSqlInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
 
-        protected override async Task PopulateDatabase(NpgsqlConnection connection)
-        {
-            // Play all your migrations script here, use DBUp or any other migration tool
-            await CreateTables(connection);
-        }
+    public override async Task Initialize()
+    {
+        await base.Initialize();
+
+        await using var connection = GetDatabaseConnection();
+        await connection.OpenAsync();
+
+        using var command = connection.CreateCommand();
+        command.CommandText = @"CREATE TABLE Users (
+            user_id SERIAL PRIMARY KEY,
+            username VARCHAR(50) NOT NULL UNIQUE
+        );";
+        await command.ExecuteNonQueryAsync();
     }
+}
 ```
 
-#### Generating configuration
+#### Generating configuration for the web app
 
-You can generate configuration for your web application by overriding the `Initialize` method :
+Override `ConnectionStringKey` (default: `ConnectionStrings:Default`):
 
 ```csharp
-   public class PostgreSqlInfrastructure : PostgreContainerAsyncInfrastructure, IConfigurable
-    {
-        public PostgreSqlInfrastructure()
-        {
-        }
+public class PostgreSqlInfrastructure : PostgreContainerInfrastructure
+{
+    public PostgreSqlInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
 
-        public override async Task Initialize()
-        {
-            await base.Initialize();
-            // We can add the connection string to the configuration.
-            Configuration.Add("ConnectionStrings:PostgreSql", GetDatabaseConnectionString());
-        }
-    }
+    protected override string ConnectionStringKey => "ConnectionStrings:PostgreSql";
+}
 ```
 
 #### Configure the container
 
-You can configure the container by overriding the `ConfigureSqlContainer` method :
-
 ```csharp
-   public class PostgreSqlInfrastructure : PostgreContainerAsyncInfrastructure
-    {
-        public PostgreSqlInfrastructure()
-        {
-        }
+public class PostgreSqlInfrastructure : PostgreContainerInfrastructure
+{
+    public PostgreSqlInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
 
-        protected override PostgreSqlBuilder ConfigureSqlContainer(PostgreSqlBuilder builder)
-        {
-            // Configure the builder to override image, host, password, port, etc.
-            return builder.WithPassword("NotoriousStrong(!)Password6");
-        }
+    protected override PostgreSqlBuilder ConfigureSqlContainer(PostgreSqlBuilder builder)
+    {
+        return builder.WithPassword("NotoriousStrong(!)Password6");
     }
+}
 ```
 
-#### Configure respawn settings
-
-To configure respawn settings, you can assign RespawnOptions property. They will be used by respawn to reset the database.
+#### Configuring Respawn (table filtering)
 
 ```csharp
-   public class PostgreSqlInfrastructure : PostgreContainerAsyncInfrastructure
+public class PostgreSqlInfrastructure : PostgreContainerInfrastructure
+{
+    public PostgreSqlInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry)
     {
-        public PostgreSqlInfrastructure()
-        {
-            RespawnOptions = new RespawnerOptions
-            {
-                TablesToIgnore = new Table[] { "MyMigrationTable" },
-                DbAdapter = DbAdapter.Postgres // Remind to set DB Adapter to Postgre.
-            };
-        }
+        TableToIgnore = ["Migrations"];
     }
+}
 ```
 
-#### Configure the database name
-
-By default, Database name will be `NotoriousDb` concatened with the `ContextId`.
-You can override `NotoriousDb` by your custom name by setting the property `DbName`.
+#### Configure the database name prefix
 
 ```csharp
-   public class PostgreSqlInfrastructure : PostgreContainerAsyncInfrastructure
+public class PostgreSqlInfrastructure : PostgreContainerInfrastructure
+{
+    public PostgreSqlInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry)
     {
-        public SqlServerInfrastructure()
-        {
-            DbName = "TestDb";
-        }
+        DbPrefix = "TestDb";
     }
+}
+```
+
+---
+
+### PostgreSQL (External)
+
+For scenarios where a PostgreSQL instance is already running, use `PostgreInfrastructure` (from `NotoriousTest.PostgreSql`).
+
+Connection settings are loaded from `testsettings.json`:
+
+```json
+{
+  "PostgreInfrastructure": {
+    "ConnectionString": "Host=localhost;Username=postgres;Password=yourPassword;"
+  }
+}
+```
+
+```csharp
+public class PostgreSqlInfrastructure : PostgreInfrastructure
+{
+    public PostgreSqlInfrastructure(EnvironmentId contextId, ITestSettingsProvider settingsProvider, ITestLogger logger, IRegistry registry)
+        : base(contextId, settingsProvider, logger, registry) { }
+
+    protected override string ConnectionStringKey => "ConnectionStrings:PostgreSql";
+}
 ```

--- a/Documentation/5-example.md
+++ b/Documentation/5-example.md
@@ -1,10 +1,10 @@
 ## Hands-On Examples
 
-Get started quickly with practical examples available in the [Samples](./Samples/NotoriousTests.InfrastructuresSamples/) folder. These examples demonstrate how to set up and use NotoriousTests for real-world scenarios.
+Get started quickly with practical examples available in the [Samples](../Samples/NotoriousTests.InfrastructuresSamples/) folder. These examples demonstrate how to set up and use NotoriousTests for real-world scenarios.
 
-### Basic example with Sql Server and a Web API.
+### Basic example with SQL Server and a Web API
 
-Lets test this feature of my application with **NotoriousTest** :
+Let's test this feature of the application with **NotoriousTest**:
 
 ```csharp
 [HttpPost]
@@ -33,112 +33,116 @@ private void CreateUser(SqlConnection sqlConnection)
 
 ### Setup
 
-Create a xUnit Test Project.
-First, [install NuGet](http://docs.nuget.org/docs/start-here/installing-nuget). Then, install [NotoriousTest](https://www.nuget.org/packages/NotoriousTest/) from the .NET CLI as:
+Create an xUnit Test Project. Then install the required packages:
 
 ```sh
 dotnet add package NotoriousTest
+dotnet add package NotoriousTest.SqlServer
 ```
 
 ### Create and populate the database
 
 ```csharp
-   public class SqlServerInfrastructure : SqlServerContainerAsyncInfrastructure, IConfigurable
+public class SqlServerInfrastructure : SqlServerContainerInfrastructure
+{
+    public SqlServerInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
+
+    // Publish the connection string under the key the web app expects
+    protected override string ConnectionStringKey => "ConnectionStrings:SqlServer";
+
+    public override async Task Initialize()
     {
-        public SqlServerInfrastructure()
-        {
-        }
+        await base.Initialize();
 
-        protected override async Task PopulateDatabase(SqlConnection connection)
-        {
-            // Play all your migrations script here, use DBUp or any other migration tool
-            using (SqlCommand command = connection.CreateCommand())
-            {
-                string sql = @"CREATE TABLE Users (
-                                    user_id INT IDENTITY(1,1) PRIMARY KEY,
-                                    username NVARCHAR(50) NOT NULL UNIQUE,
-                                    email NVARCHAR(100) NOT NULL UNIQUE,
-                                    password_hash NVARCHAR(255) NOT NULL,
-                                    created_at DATETIME DEFAULT GETDATE()
-                                );
-                               ";
-                command.CommandText = sql;
-                await command.ExecuteNonQueryAsync();
-            }
-        }
+        // Run schema migrations after the container and database are ready
+        await using var connection = GetDatabaseConnection();
+        await connection.OpenAsync();
 
-        public override async Task Initialize()
-        {
-            await base.Initialize();
-            // We can add the connection string to the configuration.
-            AddConfigurationEntry("ConnectionStrings:SqlServer", GetDatabaseConnectionString());
-        }
+        using var command = connection.CreateCommand();
+        command.CommandText = @"CREATE TABLE Users (
+            user_id INT IDENTITY(1,1) PRIMARY KEY,
+            username NVARCHAR(50) NOT NULL UNIQUE,
+            email NVARCHAR(100) NOT NULL UNIQUE,
+            password_hash NVARCHAR(255) NOT NULL,
+            created_at DATETIME DEFAULT GETDATE()
+        );";
+        await command.ExecuteNonQueryAsync();
     }
+}
 ```
 
 ### Create the WebApplication
 
 ```csharp
-    public class SampleProjectApp : WebApplication<Program>{}
+public class SampleProjectApp : WebApplication<Program> { }
 ```
 
 ### Create the environment
 
 ```csharp
-    public class TestEnvironment : AsyncWebEnvironment<Program>
+public class TestEnvironment : NotoriousTest.XUnit.Environment
+{
+    public TestEnvironment(IMessageSink sink) : base(sink) { }
+    public override Assembly CurrentAssembly => Assembly.GetExecutingAssembly();
+
+    public override async Task ConfigureEnvironment()
     {
-        public override async Task ConfigureEnvironmentAsync()
-        {
-            await AddInfrastructure(new SqlServerInfrastructure());
-            await AddWebApplication(new TestWebApplication());
-        }
+        AddInfrastructure<SqlServerInfrastructure>();
+        this.AddWebApplication<SampleProjectApp>();
     }
+}
 ```
 
 ### Run the tests
 
 ```csharp
-[Fact]
-public async Task Test1()
+public class SampleTests : IntegrationTest<TestEnvironment>
 {
-    HttpClient client = (await CurrentEnvironment.GetWebApplication()).HttpClient;
-    HttpResponseMessage response = await client.PostAsync("users", null);
-    Assert.True(response.IsSuccessStatusCode);
+    public SampleTests(TestEnvironment environment) : base(environment) { }
 
-    SqlServerInfrastructure sqlInfrastructure = await CurrentEnvironment.GetInfrastructureAsync<SqlServerInfrastructure>();
-
-    await using(SqlConnection sql = sqlInfrastructure.GetDatabaseConnection())
+    [Fact]
+    public async Task Test1()
     {
-        await sql.OpenAsync();
-        using (SqlCommand command = sql.CreateCommand())
+        HttpClient client = CurrentEnvironment.GetWebApplication().HttpClient;
+        HttpResponseMessage response = await client.PostAsync("users", null);
+        Assert.True(response.IsSuccessStatusCode);
+
+        SqlServerInfrastructure sqlInfrastructure = CurrentEnvironment.GetInfrastructure<SqlServerInfrastructure>();
+
+        await using (DbConnection sql = sqlInfrastructure.GetDatabaseConnection())
         {
-            command.CommandText = "SELECT COUNT(*) FROM Users";
-            int count = (int)await command.ExecuteScalarAsync();
-            Assert.Equal(1, count);
+            await sql.OpenAsync();
+            using (DbCommand command = sql.CreateCommand())
+            {
+                command.CommandText = "SELECT COUNT(*) FROM Users";
+                int count = (int)await command.ExecuteScalarAsync();
+                Assert.Equal(1, count);
+            }
         }
     }
 }
 ```
 
-### What's included:
+### What's included in the Samples folder:
 
-- **[SqlServerInfrastructures.cs](./Samples/NotoriousTests.InfrastructuresSamples/Infrastructures/SqlServerInfrastructures.cs)**  
-  Learn how to manage your SQL Server database using Respawn, TestContainers and plain SQL for creating, destroying, and resetting your database seamlessly.
-- **[TestWebApplication.cs](./Samples/NotoriousTests.InfrastructuresSamples/Infrastructures/TestWebApplication.cs)**  
+- **[SqlServerInfrastructure.cs](../Samples/NotoriousTests.InfrastructuresSamples/Infrastructures/SqlServerInfrastructure.cs)**
+  Learn how to manage your SQL Server database using Respawn, TestContainers, and plain SQL for creating, destroying, and resetting your database seamlessly.
+- **[TestWebApplication.cs](../Samples/NotoriousTests.InfrastructuresSamples/Infrastructures/TestWebApplication.cs)**
   See how to configure a WebApplicationFactory with in-memory configuration for fast and isolated tests.
-- **[TestEnvironment](./Samples/NotoriousTests.InfrastructuresSamples/Environments/TestEnvironment.cs)**  
+- **[TestEnvironment.cs](../Samples/NotoriousTests.InfrastructuresSamples/Environments/TestEnvironment.cs)**
   Understand how to set up environments to manage multiple infrastructures effortlessly.
-- **[SampleTests.cs](./Samples/NotoriousTests.InfrastructuresSamples/SampleTests.cs)**  
+- **[SampleTests.cs](../Samples/NotoriousTests.InfrastructuresSamples/SampleTests.cs)**
   Dive into this file to see how to access infrastructures and use them in your tests.
-- **[Program.cs](./Samples/NotoriousTests.InfrastructuresSamples.TestWebApp/Program.cs)**  
-  Explore how the SqlServerInfrastructure generates configuration for the Web Application.\*
+- **[Program.cs](../Samples/NotoriousTests.InfrastructuresSamples.TestWebApp/Program.cs)**
+  Explore how the SqlServerInfrastructure generates configuration for the Web Application.
 
 ## ✅ Next Steps
 
 Now that your first test is running, explore more features:
 
 - 📖 [Core Concepts](./2-core-concepts.md) – Learn how infrastructures and environments work.
-- ⚡ [Advanced Features](./3-advanced-features.md) – Discover ordering, reset behaviors, and more. \
+- ⚡ [Advanced Features](./3-advanced-features.md) – Discover ordering, reset behaviors, extensions, DI, and logging.
 - 🔌 [Supported Infrastructures](./4-integrations.md) – See how to integrate SQL Server, TestContainers, and more.
 
 💡 Need help or have feedback? Join the community [discussions](https://github.com/Notorious-Coding/Notorious-Test/discussions) or open an [issue](https://github.com/Notorious-Coding/Notorious-Test/issues) on GitHub.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ __Clean, isolated, and maintainable integration testing for .NET__
 [![NuGet](https://img.shields.io/nuget/v/NotoriousTest)](https://www.nuget.org/packages/NotoriousTest/)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/NotoriousTest)](https://www.nuget.org/packages/NotoriousTest/)
 [![License](https://img.shields.io/github/license/Notorious-Coding/Notorious-Test)](https://github.com/Notorious-Coding/Notorious-Test/blob/master/LICENSE.txt)
-[![.NET](https://img.shields.io/badge/.NET-6%2B-blue)](https://dotnet.microsoft.com/)
+[![.NET](https://img.shields.io/badge/.NET-8%2B-blue)](https://dotnet.microsoft.com/)
 [![Build Status](https://github.com/Notorious-Coding/Notorious-Test/actions/workflows/release.yml/badge.svg)](https://github.com/Notorious-Coding/Notorious-Test/actions/workflows/release.yml)
 [![GitHub stars](https://img.shields.io/github/stars/Notorious-Coding/Notorious-Test?style=social)](https://github.com/Notorious-Coding/Notorious-Test/stargazers)
 
@@ -60,8 +60,11 @@ For now, we’ll define an empty infrastructure to illustrate the setup.
 You can replace `MyInfrastructure` with any real infrastructure later.
 
 ```csharp
-public class MyInfrastructure : AsyncInfrastructure
+public class MyInfrastructure : Infrastructure
 {
+    public MyInfrastructure(EnvironmentId contextId, ITestLogger logger, IRegistry registry)
+        : base(contextId, logger, registry) { }
+
     public override Task Initialize()
     {
         // Setup logic here (e.g., start a database, configure an API)
@@ -112,12 +115,15 @@ public class SampleWebApp : WebApplication<Program>
 A test environment groups infrastructures together.
 
 ```csharp
-public class MyTestEnvironment : AsyncWebEnvironment
+public class MyTestEnvironment : NotoriousTest.XUnit.Environment
 {
-    public override async Task ConfigureEnvironmentAsync()
+    public MyTestEnvironment(IMessageSink sink) : base(sink) { }
+    public override Assembly CurrentAssembly => Assembly.GetExecutingAssembly();
+
+    public override async Task ConfigureEnvironment()
     {
-        AddInfrastructure(new MyInfrastructure()); // Register the test infrastructure
-        AddWebApplication(new SampleWebApp()); // Register the web app
+        AddInfrastructure<MyInfrastructure>(); // Register via DI
+        this.AddWebApplication<SampleWebApp>(); // Register the web app
     }
 }
 ```
@@ -132,7 +138,7 @@ public class MyTestEnvironment : AsyncWebEnvironment
 Now, let's write a basic integration test using our environment.
 
 ```csharp
-public class MyIntegrationTests : AsyncIntegrationTest<MyTestEnvironment>
+public class MyIntegrationTests : IntegrationTest<MyTestEnvironment>
 {
     public MyIntegrationTests(MyTestEnvironment environment) : base(environment) { }
 
@@ -140,7 +146,7 @@ public class MyIntegrationTests : AsyncIntegrationTest<MyTestEnvironment>
     public async Task ExampleTest()
     {
         // Retrieve the infrastructure
-        var infra = await CurrentEnvironment.GetInfrastructureAsync<MyInfrastructure>();
+        var infra = CurrentEnvironment.GetInfrastructure<MyInfrastructure>();
 
         // Add test logic here (e.g., verify database state, call an API)
 


### PR DESCRIPTION
- Rename AsyncInfrastructure/AsyncEnvironment/AsyncWebEnvironment to their non-Async equivalents (Infrastructure, Environment, WebEnvironment pattern)
- Fix ConfigureEnvironmentAsync -> ConfigureEnvironment and GetInfrastructureAsync<T> -> GetInfrastructure<T>
- Show correct DI constructor pattern for infrastructures
- Replace IConfigurable/Configuration.Add() with ConnectionStringKey override
- Replace RespawnOptions property with TableToIgnore/TableToInclude init props
- Replace DbName with DbPrefix; replace PopulateDatabase with Initialize() override
- Fix DockerContainerInfrastructure to use two type parameters
- Update .NET badge from 6+ to 8+
- Add new sections: Extensions, DI, Logging, SQL Server (External), PostgreSQL (External)
- Fix broken CHANGELOG links pointing to old README anchors
- Remove stray 'git stash' text from CHANGELOG