### PR TITLE
feat: add .editorconfig with C# conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -139,6 +139,8 @@ dotnet_naming_style.underscore_camel_case.capitalization = camel_case
 
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
+dotnet_naming_style.all_upper_snake_case.capitalization = all_upper
+
 dotnet_naming_style.camel_case.capitalization = camel_case
 
 dotnet_naming_style.interface_prefix.required_prefix = I
@@ -154,9 +156,9 @@ dotnet_naming_rule.private_fields_underscore.symbols = private_fields
 dotnet_naming_rule.private_fields_underscore.style = underscore_camel_case
 dotnet_naming_rule.private_fields_underscore.severity = suggestion
 
-dotnet_naming_rule.const_pascal_case.symbols = const_fields
-dotnet_naming_rule.const_pascal_case.style = pascal_case
-dotnet_naming_rule.const_pascal_case.severity = suggestion
+dotnet_naming_rule.const_upper_snake_case.symbols = const_fields
+dotnet_naming_rule.const_upper_snake_case.style = all_upper_snake_case
+dotnet_naming_rule.const_upper_snake_case.severity = suggestion
 
 dotnet_naming_rule.interfaces_prefix_i.symbols = interfaces
 dotnet_naming_rule.interfaces_prefix_i.style = interface_prefix

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,188 @@
+root = true
+
+[*]
+charset = utf-8-bom
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.cs]
+
+# ──────────────────────────────────────────────
+# Namespaces & usings
+# ──────────────────────────────────────────────
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# ──────────────────────────────────────────────
+# var
+# ──────────────────────────────────────────────
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = false:suggestion
+
+# ──────────────────────────────────────────────
+# Braces – Allman style
+# ──────────────────────────────────────────────
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+# ──────────────────────────────────────────────
+# Indentation
+# ──────────────────────────────────────────────
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+# ──────────────────────────────────────────────
+# Spacing
+# ──────────────────────────────────────────────
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+
+# ──────────────────────────────────────────────
+# Expression-bodied members
+# ──────────────────────────────────────────────
+csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_operators = false:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_lambdas = true:suggestion
+csharp_style_expression_bodied_local_functions = false:suggestion
+
+# ──────────────────────────────────────────────
+# Pattern matching & null handling
+# ──────────────────────────────────────────────
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+
+# ──────────────────────────────────────────────
+# Modifiers
+# ──────────────────────────────────────────────
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+csharp_prefer_static_local_function = true:suggestion
+csharp_preferred_modifier_order = public, private, protected, internal, file, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, required, volatile, async
+
+# ──────────────────────────────────────────────
+# .NET style preferences
+# ──────────────────────────────────────────────
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_event = false:suggestion
+
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+
+# ──────────────────────────────────────────────
+# Naming – symbols
+# ──────────────────────────────────────────────
+dotnet_naming_symbols.private_fields.applicable_kinds = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, private_protected
+
+dotnet_naming_symbols.const_fields.applicable_kinds = field
+dotnet_naming_symbols.const_fields.required_modifiers = const
+
+dotnet_naming_symbols.interfaces.applicable_kinds = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = *
+
+dotnet_naming_symbols.type_parameters.applicable_kinds = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds = class, struct, enum, namespace, delegate
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = *
+
+dotnet_naming_symbols.public_members.applicable_kinds = property, method, event, field
+dotnet_naming_symbols.public_members.applicable_accessibilities = public, internal, protected, protected_internal
+
+dotnet_naming_symbols.local_variables.applicable_kinds = local, parameter
+dotnet_naming_symbols.local_variables.applicable_accessibilities = *
+
+# ──────────────────────────────────────────────
+# Naming – styles
+# ──────────────────────────────────────────────
+dotnet_naming_style.underscore_camel_case.required_prefix = _
+dotnet_naming_style.underscore_camel_case.capitalization = camel_case
+
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.camel_case.capitalization = camel_case
+
+dotnet_naming_style.interface_prefix.required_prefix = I
+dotnet_naming_style.interface_prefix.capitalization = pascal_case
+
+dotnet_naming_style.type_parameter_prefix.required_prefix = T
+dotnet_naming_style.type_parameter_prefix.capitalization = pascal_case
+
+# ──────────────────────────────────────────────
+# Naming – rules
+# ──────────────────────────────────────────────
+dotnet_naming_rule.private_fields_underscore.symbols = private_fields
+dotnet_naming_rule.private_fields_underscore.style = underscore_camel_case
+dotnet_naming_rule.private_fields_underscore.severity = suggestion
+
+dotnet_naming_rule.const_pascal_case.symbols = const_fields
+dotnet_naming_rule.const_pascal_case.style = pascal_case
+dotnet_naming_rule.const_pascal_case.severity = suggestion
+
+dotnet_naming_rule.interfaces_prefix_i.symbols = interfaces
+dotnet_naming_rule.interfaces_prefix_i.style = interface_prefix
+dotnet_naming_rule.interfaces_prefix_i.severity = suggestion
+
+dotnet_naming_rule.type_parameters_prefix_t.symbols = type_parameters
+dotnet_naming_rule.type_parameters_prefix_t.style = type_parameter_prefix
+dotnet_naming_rule.type_parameters_prefix_t.severity = suggestion
+
+dotnet_naming_rule.types_pascal_case.symbols = types_and_namespaces
+dotnet_naming_rule.types_pascal_case.style = pascal_case
+dotnet_naming_rule.types_pascal_case.severity = suggestion
+
+dotnet_naming_rule.public_members_pascal_case.symbols = public_members
+dotnet_naming_rule.public_members_pascal_case.style = pascal_case
+dotnet_naming_rule.public_members_pascal_case.severity = suggestion
+
+dotnet_naming_rule.locals_camel_case.symbols = local_variables
+dotnet_naming_rule.locals_camel_case.style = camel_case
+dotnet_naming_rule.locals_camel_case.severity = suggestion
+
+# ──────────────────────────────────────────────
+# Project & config files
+# ──────────────────────────────────────────────
+[*.{csproj,props,targets,slnx}]
+indent_size = 2
+
+[*.{json,yml,yaml}]
+indent_size = 2


### PR DESCRIPTION
## Summary

- Ajoute un `.editorconfig` à la racine du projet pour standardiser le style de code C#
- Champs `private`/`private_protected` → `_camelCase` (suggestion, Alt+Entrée automatique)
- Champs `protected` et membres publics → `PascalCase`
- Namespaces file-scoped, `using` en dehors du namespace
- Style Allman pour les accolades
- `var` uniquement quand le type est apparent (`new Foo()`, casts, génériques)
- Toutes les règles en `suggestion` : soulignement vert, aucun warning/erreur bloquant à la compilation

## Reviewer notes

Toutes les règles sont à sévérité `suggestion` — elles n'impactent pas la compilation ni le CI. Elles s'appliquent via Roslyn dans l'IDE (Visual Studio / Rider) et offrent des quick-fixes automatiques via Alt+Entrée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)