### PR TITLE
docs: add CONTRIBUTING guide, issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour in NotoriousTest
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as possible.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Step-by-step instructions to reproduce the issue.
+      placeholder: |
+        1. Create an environment with ...
+        2. Run the test ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include any error messages or stack traces.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: framework
+    attributes:
+      label: Test framework
+      options:
+        - xUnit
+        - NUnit
+        - MSTest
+        - TUnit
+        - Not applicable
+    validations:
+      required: true
+
+  - type: input
+    id: package-version
+    attributes:
+      label: NotoriousTest version
+      placeholder: e.g. 2.3.0
+    validations:
+      required: true
+
+  - type: input
+    id: dotnet-version
+    attributes:
+      label: .NET version
+      placeholder: e.g. .NET 10
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction-project
+    attributes:
+      label: Minimal reproduction project
+      description: Link to a repository or a code snippet that reproduces the issue (optional but greatly appreciated).
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other information that might be relevant (OS, Docker version, CI environment, etc.).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Suggest a new feature or enhancement for NotoriousTest
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please describe your idea in detail so we can discuss it.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What problem or limitation are you running into? Why does the current behaviour fall short?
+      placeholder: I keep having to write boilerplate code to ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the feature or change you would like to see. Include API design ideas if you have any.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Are there other approaches you thought of? Why did you prefer the proposed solution?
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Which part of the project does this affect?
+      multiple: true
+      options:
+        - Core / Runtime
+        - DoggyDog (Watchdog)
+        - xUnit adapter
+        - NUnit adapter
+        - MSTest adapter
+        - TUnit adapter
+        - Database infrastructure
+        - TestContainers infrastructure
+        - Web infrastructure
+        - Documentation
+        - CI/CD
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Any other information, links, or references that support this request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@ Closes #
 - [ ] Samples are still functional.
 - [ ] Documentation updated (`README.md` and/or files in `Documentation/`).
 - [ ] `CHANGELOG.md` updated under the appropriate version heading.
+- [ ] PreRelease pipeline passes (test locally with [act](https://github.com/nektos/act) before pushing).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- Describe what this PR does and why. Link the related issue below. -->
+
+Closes #
+
+## Definition of Done
+
+- [ ] Unit tests added or updated.
+- [ ] Integration tests added or updated.
+- [ ] Samples are still functional.
+- [ ] Documentation updated (`README.md` and/or files in `Documentation/`).
+- [ ] `CHANGELOG.md` updated under the appropriate version heading.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,213 @@
+# Contributing to NotoriousTest
+
+Thank you for your interest in contributing to **NotoriousTest**! All contributions are welcome, whether it's bug reports, feature requests, documentation improvements, or code changes.
+
+## Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [Getting Started](#getting-started)
+- [Project Structure](#project-structure)
+- [How to Contribute](#how-to-contribute)
+  - [Reporting Bugs](#reporting-bugs)
+  - [Suggesting Features](#suggesting-features)
+  - [Submitting Pull Requests](#submitting-pull-requests)
+- [Development Setup](#development-setup)
+- [Coding Conventions](#coding-conventions)
+- [Testing](#testing)
+- [Releasing](#releasing)
+
+---
+
+## Code of Conduct
+
+Please be respectful and constructive in all interactions. We want this project to be a welcoming place for everyone.
+
+---
+
+## Getting Started
+
+1. **Fork** the repository on GitHub.
+2. **Clone** your fork locally:
+   ```bash
+   git clone https://github.com/<your-username>/Notorious-Test.git
+   cd Notorious-Test
+   ```
+3. **Create a branch** for your change:
+   ```bash
+   git checkout -b feature/my-feature
+   ```
+
+---
+
+## Project Structure
+
+```
+NotoriousTest/               # Orchestration package
+NotoriousTest.Core/          # Main package (core abstractions)
+NotoriousTest.Runtime/       # Lifecycle runtime
+DoggyDog/                    # Watchdog — cleanup after unexpected crashes
+NotoriousTest.{XUnit,NUnit,MSTest,TUnit}/   # Test framework adapters
+NotoriousTest.{Database,Sqlite,SqlServer,PostgreSql,TestContainers,Web}/  # Infrastructure implementations
+Samples/                     # Example projects per framework
+Documentation/               # In-depth guides
+```
+
+---
+
+## How to Contribute
+
+### Reporting Bugs
+
+Use the [Bug Report template](https://github.com/Notorious-Coding/Notorious-Test/issues/new?template=bug_report.yml) when opening an issue — it will guide you through the required information (steps to reproduce, expected vs. actual behaviour, .NET version, test framework, NotoriousTest version, minimal reproduction project).
+
+### Suggesting Features
+
+Use the [Feature Request template](https://github.com/Notorious-Coding/Notorious-Test/issues/new?template=feature_request.yml) when opening an issue — it will prompt you for the problem you are solving, your proposed solution, alternatives considered, and the affected scope.
+
+### Submitting Pull Requests
+
+1. Make sure an issue exists (or open one) so we can discuss the change before you invest significant time.
+2. Keep PRs focused — one concern per PR.
+3. Ensure all tests pass locally before opening the PR.
+4. Fill in the PR description with context and a link to the related issue.
+
+### Definition of Done
+
+A PR is considered ready to merge when all of the following are true:
+
+- [ ] Unit tests added or updated.
+- [ ] Integration tests added or updated.
+- [ ] Samples are still functional.
+- [ ] Documentation updated (`README.md` and/or files in `Documentation/`).
+- [ ] `CHANGELOG.md` updated under the appropriate version heading.
+
+---
+
+## Development Setup
+
+**Prerequisites:**
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download) or later.
+- Docker (required for TestContainers-based tests).
+
+**Build everything:**
+
+```bash
+dotnet build
+```
+
+**Run all tests:**
+
+```bash
+dotnet test
+```
+
+---
+
+## Coding Conventions
+
+This project follows the C# conventions defined in [`.editorconfig`](.editorconfig):
+
+- Constants use `SCREAMING_SNAKE_CASE`.
+- Follow the existing style in the file you are editing — consistency matters more than personal preference.
+- No unnecessary comments; let well-named identifiers speak for themselves.
+- Do not add error handling for scenarios that cannot happen; trust framework guarantees.
+- Use `dotnet format` to apply code styles if necessary.
+
+---
+
+## Testing
+
+- Each new infrastructure or feature must be covered by integration tests.
+- Tests should be fully isolated — no shared mutable state between test runs.
+
+---
+
+## Running DoggyDog Manually
+
+DoggyDog is normally spawned automatically by the test framework. When working on DoggyDog itself (or debugging the watchdog lifecycle), you can launch it manually.
+
+### 1. Enable manual launch mode in your test project
+
+In your `testsettings.json`, set `ManualLaunch` to `true`:
+
+```json
+{
+  "Environment": {
+    "DisableWatchdog": false
+  },
+  "Watchdog": {
+    "ManualLaunch": true
+  }
+}
+```
+
+When this flag is set, NotoriousTest will **not** spawn DoggyDog automatically. Instead, it will write the required parameters as user-scoped environment variables (`DOGGYDOG_DEBUG_*`) and then poll for a running `DoggyDog` process every 5 seconds before proceeding with the tests.
+
+### 2. Start DoggyDog from your IDE
+
+Two launch profiles are already defined in [`DoggyDog/Properties/launchSettings.json`](DoggyDog/Properties/launchSettings.json):
+
+| Profile | Command line | When to use |
+|---|---|---|
+| **With env params** | `--from-env` | Use together with `ManualLaunch: true` — reads the `DOGGYDOG_DEBUG_*` env vars written by NotoriousTest automatically |
+| **With arguments** | full argument list | Use when you want to supply every parameter manually (hardcoded paths, specific PID, etc.) |
+
+Select the appropriate profile in Visual Studio / Rider and hit **Run** or **Debug**.
+
+If you prefer the command line, the equivalent invocations are:
+
+```bash
+# Option A — read from environment variables (requires ManualLaunch: true)
+DoggyDog --from-env
+
+# Option B — direct arguments
+DoggyDog \
+  --pid <test-runner-pid> \
+  --assembly "<path-to-test-assembly.dll>" \
+  --connectionString "Data Source=<path-to-registry.db>" \
+  --environment "<environment-guid>" \
+  [--runtimes "<runtime-path-1>|<runtime-path-2>"] \
+  [--loglevel Debug]
+```
+
+| Argument | Required | Description |
+|---|---|---|
+| `--pid` | Yes | PID of the test runner process to monitor |
+| `--assembly` | Yes | Full path to the test assembly (`.dll`) |
+| `--connectionString` | Yes | SQLite connection string to the infrastructure registry |
+| `--environment` | Yes | Environment GUID that identifies the test session |
+| `--runtimes` | No | Pipe-delimited list test project runtimes |
+| `--loglevel` | No | `Error`, `Warning`, `Success`, `Info` (default), `Trace`, or `Debug` |
+
+### 3. Attach a debugger (optional)
+
+With `ManualLaunch: true` the tests will wait until a `DoggyDog` process is detected. Start DoggyDog with the **With env params** profile in debug mode — your IDE will attach automatically before the test session proceeds.
+
+### Disabling DoggyDog entirely
+
+If you want to run tests without any watchdog (e.g., in a restricted environment without SQLite or Docker), set `DisableWatchdog: true`:
+
+```json
+{
+  "Environment": {
+    "DisableWatchdog": true
+  }
+}
+```
+
+---
+
+## Releasing
+
+Releases are handled by the maintainer via the GitHub Actions workflows:
+
+- **Pre-release:** `.github/workflows/prerelease.yml`: Triggered by pull request and push to develop
+- **Release:** `.github/workflows/release.yml`: Triggered by github releases.
+
+Contributors do not need to worry about releases; just make sure `CHANGELOG.md` is updated in your PR.
+
+Do not hesitate to test prerelease workflow changes with [act](https://github.com/nektos/act).
+---
+
+Questions? Start a [discussion](https://github.com/Notorious-Coding/Notorious-Test/discussions) or open an issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ A PR is considered ready to merge when all of the following are true:
 - [ ] Samples are still functional.
 - [ ] Documentation updated (`README.md` and/or files in `Documentation/`).
 - [ ] `CHANGELOG.md` updated under the appropriate version heading.
+- [ ] PreRelease pipeline passes (test locally with [act](https://github.com/nektos/act) before pushing).
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` covering project structure, coding conventions, development setup, DoggyDog manual launch guide (with a reference to the two existing IDE launch profiles), and a Definition of Done checklist.
- Add GitHub issue templates for **Bug Reports** and **Feature Requests** (`.github/ISSUE_TEMPLATE/`).
- Add a **PR template** (`.github/PULL_REQUEST_TEMPLATE.md`) that pre-fills the Definition of Done checklist on every new pull request.

## Definition of Done

- [ ] Unit tests added or updated.
- [ ] Integration tests added or updated.
- [ ] Samples are still functional.
- [ ] Documentation updated (`README.md` and/or files in `Documentation/`).
- [ ] `CHANGELOG.md` updated under the appropriate version heading.