### PR TITLE
fix: resolve all warnings and enable TreatWarningsAsErrors

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <!-- Import repository-root build properties -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+</Project>

--- a/NotoriousTest.Database/DockerDatabaseInfrastructure.cs
+++ b/NotoriousTest.Database/DockerDatabaseInfrastructure.cs
@@ -1,4 +1,4 @@
-﻿using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Containers;
 
 using NotoriousTest.Logger;
 
@@ -6,30 +6,43 @@ using System.Data.Common;
 
 namespace NotoriousTest.Database
 {
+    /// <summary>
+    /// Base class for database infrastructures backed by a Testcontainers Docker container.
+    /// </summary>
+    /// <typeparam name="TContainer">The Testcontainers database container type.</typeparam>
+    /// <typeparam name="TOutputConfiguration">The type of configuration value produced by this infrastructure.</typeparam>
     public abstract class DockerDatabaseInfrastructure<TContainer, TOutputConfiguration> : DatabaseInfrastructureBase<TOutputConfiguration> where TContainer : IDatabaseContainer
     {
+        /// <summary>Initializes a new instance with the given context and logger.</summary>
+        /// <param name="contextId">The environment context identifier.</param>
+        /// <param name="logger">The test logger.</param>
         protected DockerDatabaseInfrastructure(ContextId contextId, ITestLogger logger) : base(contextId, logger)
         {
         }
 
-        protected TContainer Container { get; init; }
+        /// <summary>Gets the Testcontainers database container managed by this infrastructure.</summary>
+        protected TContainer Container { get; init; } = default!;
 
+        /// <inheritdoc/>
         public override async Task Initialize()
         {
             await Container.StartAsync();
             await base.Initialize();
         }
 
+        /// <inheritdoc/>
         public override async Task Destroy()
         {
             await Container.StopAsync();
         }
 
+        /// <inheritdoc/>
         public override string GetServerConnectionString()
         {
             return Container.GetConnectionString();
         }
 
+        /// <inheritdoc/>
         protected override async Task DropDatabase(DbConnection connection)
         {
             // Dropping the database is unnecessary since the Docker container is destroyed with it.

--- a/NotoriousTest.Database/NotoriousTest.Database.csproj
+++ b/NotoriousTest.Database/NotoriousTest.Database.csproj
@@ -22,7 +22,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Respawn" Version="7.0.0" />
+		<PackageReference Include="Respawn" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NotoriousTest.Database/RespawnExtension.cs
+++ b/NotoriousTest.Database/RespawnExtension.cs
@@ -1,17 +1,23 @@
-﻿using Respawn;
+using Respawn;
 
 namespace NotoriousTest.Database
 {
+    /// <summary>
+    /// Infrastructure extension that uses Respawn to reset the database to a clean state between tests.
+    /// </summary>
     public class RespawnExtension : IInfrastructureExtension<IDatabaseInfrastructure>
     {
         private readonly Func<RespawnerOptions>? _optionsFactory;
-        private Respawner _respawner;
+        private Respawner? _respawner;
 
+        /// <summary>Initializes a new instance with an optional Respawn options factory.</summary>
+        /// <param name="optionsFactory">Factory returning the Respawn options, or null to use defaults.</param>
         public RespawnExtension(Func<RespawnerOptions>? optionsFactory = null)
         {
             _optionsFactory = optionsFactory;
         }
 
+        /// <summary>Creates the Respawner after the database infrastructure is initialized.</summary>
         public async Task OnAfterInitialize(IDatabaseInfrastructure infra)
         {
             using var connection = infra.GetDatabaseConnection();
@@ -19,11 +25,12 @@ namespace NotoriousTest.Database
             _respawner = await Respawner.CreateAsync(connection, _optionsFactory?.Invoke());
         }
 
+        /// <summary>Resets the database to the checkpoint state before each test reset.</summary>
         public async Task OnBeforeReset(IDatabaseInfrastructure infra)
         {
             using var connection = infra.GetDatabaseConnection();
             await connection.OpenAsync();
-            await _respawner.ResetAsync(connection);
+            await _respawner!.ResetAsync(connection);
         }
     }
 }

--- a/NotoriousTest.Database/Settings/DatabaseSettings.cs
+++ b/NotoriousTest.Database/Settings/DatabaseSettings.cs
@@ -1,7 +1,11 @@
-﻿namespace NotoriousTest.Database.Settings
+namespace NotoriousTest.Database.Settings
 {
+    /// <summary>
+    /// Holds database connection settings loaded from test settings.
+    /// </summary>
     public class DatabaseSettings
     {
-        public string ConnectionString { get; set; }
+        /// <summary>Gets or sets the database connection string.</summary>
+        public string ConnectionString { get; set; } = string.Empty;
     }
 }

--- a/NotoriousTest.PostgreSql/NotoriousTest.PostgreSql.csproj
+++ b/NotoriousTest.PostgreSql/NotoriousTest.PostgreSql.csproj
@@ -22,9 +22,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Npgsql" Version="10.0.2" />
-		<PackageReference Include="Respawn" Version="7.0.0" />
-		<PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+		<PackageReference Include="Npgsql" />
+		<PackageReference Include="Respawn" />
+		<PackageReference Include="Testcontainers.PostgreSql" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NotoriousTest.PostgreSql/PostgreContainerInfrastructure.cs
+++ b/NotoriousTest.PostgreSql/PostgreContainerInfrastructure.cs
@@ -40,7 +40,9 @@ public class PostgreContainerInfrastructure<TOutputConfiguration> : DockerDataba
 
     public PostgreContainerInfrastructure(Guid contextId, ITestLogger logger) : base(contextId, logger)
     {
+#pragma warning disable CS0618
         Container = ConfigureSqlContainer(new PostgreSqlBuilder()).Build();
+#pragma warning restore CS0618
         EnsureExtension(new RespawnExtension(() => new RespawnerOptions()
         {
             TablesToIgnore = TableToIgnore.Select(tti => new Table(tti)).ToArray(),

--- a/NotoriousTest.SampleProject.Tests/NotoriousTest.SampleProject.Tests.csproj
+++ b/NotoriousTest.SampleProject.Tests/NotoriousTest.SampleProject.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.1.0" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.MsSql" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NotoriousTest.SampleProject/NotoriousTest.SampleProject.csproj
+++ b/NotoriousTest.SampleProject/NotoriousTest.SampleProject.csproj
@@ -11,7 +11,7 @@
 		<InternalsVisibleTo Include="NotoriousTest.SampleProject.Tests" />
 	</ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/NotoriousTest.SqlServer/NotoriousTest.SqlServer.csproj
+++ b/NotoriousTest.SqlServer/NotoriousTest.SqlServer.csproj
@@ -22,9 +22,9 @@
 	</ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
-    <PackageReference Include="Respawn" Version="7.0.0" />
-    <PackageReference Include="Testcontainers.MsSql" Version="4.11.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Respawn" />
+    <PackageReference Include="Testcontainers.MsSql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NotoriousTest.SqlServer/SqlServerContainerInfrastructure.cs
+++ b/NotoriousTest.SqlServer/SqlServerContainerInfrastructure.cs
@@ -39,7 +39,9 @@ namespace NotoriousTest.SqlServer
 
         public SqlServerContainerInfrastructure(ContextId contextId, ITestLogger logger) : base(contextId, logger)
         {
+#pragma warning disable CS0618
             Container = ConfigureSqlContainer(new MsSqlBuilder()).Build();
+#pragma warning restore CS0618
             EnsureExtension(new RespawnExtension(() => new RespawnerOptions()
             {
                 TablesToIgnore = TableToIgnore.Select(tti => new Table(tti)).ToArray(),

--- a/NotoriousTest.TestContainers/DockerContainerInfrastructure.cs
+++ b/NotoriousTest.TestContainers/DockerContainerInfrastructure.cs
@@ -1,24 +1,35 @@
-﻿using DotNet.Testcontainers.Containers;
+using DotNet.Testcontainers.Containers;
 
 using NotoriousTest.Infrastructures;
 using NotoriousTest.Logger;
 
 namespace NotoriousTest.TestContainers
 {
+    /// <summary>
+    /// Base class for infrastructures backed by a Testcontainers Docker container with typed output configuration.
+    /// </summary>
+    /// <typeparam name="TContainer">The Testcontainers container type.</typeparam>
+    /// <typeparam name="TOutputConfiguration">The type of configuration value produced by this infrastructure.</typeparam>
     public abstract class DockerContainerInfrastructure<TContainer, TOutputConfiguration> : Infrastructure<TOutputConfiguration>
         where TContainer : IContainer
     {
+        /// <summary>Initializes a new instance with the given context and logger.</summary>
+        /// <param name="contextId">The environment context identifier.</param>
+        /// <param name="logger">The test logger.</param>
         protected DockerContainerInfrastructure(ContextId contextId, ITestLogger logger) : base(contextId, logger)
         {
         }
 
-        protected TContainer Container { get; init; }
+        /// <summary>Gets the Docker container managed by this infrastructure.</summary>
+        protected TContainer Container { get; init; } = default!;
 
+        /// <inheritdoc/>
         public override async Task Destroy()
         {
             await Container.StopAsync();
         }
 
+        /// <inheritdoc/>
         public override async Task Initialize()
         {
             await Container.StartAsync();

--- a/NotoriousTest.TestContainers/NotoriousTest.TestContainers.csproj
+++ b/NotoriousTest.TestContainers/NotoriousTest.TestContainers.csproj
@@ -26,6 +26,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Testcontainers" Version="4.11.0" />
+	  <PackageReference Include="Testcontainers" />
 	</ItemGroup>
 </Project>

--- a/NotoriousTest.UnitTests/NotoriousTest.UnitTests.csproj
+++ b/NotoriousTest.UnitTests/NotoriousTest.UnitTests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="FakeItEasy" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NotoriousTest.Web/Applications/IWebApplication.cs
+++ b/NotoriousTest.Web/Applications/IWebApplication.cs
@@ -1,9 +1,13 @@
-﻿using NotoriousTest.Configuration;
+using NotoriousTest.Configuration;
 
 namespace NotoriousTest.Web.Applications
 {
+    /// <summary>
+    /// Represents a test web application factory that supports configuration injection and HTTP client creation.
+    /// </summary>
     public interface IWebApplication : IAsyncDisposable, IConfigurationConsumer
     {
+        /// <summary>Creates and returns a default <see cref="HttpClient"/> for the test web application.</summary>
         HttpClient CreateDefaultClient();
     }
 }

--- a/NotoriousTest.Web/Applications/WebApplication.cs
+++ b/NotoriousTest.Web/Applications/WebApplication.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 
@@ -7,22 +7,29 @@ using NotoriousTest.Web.Helpers;
 
 namespace NotoriousTest.Web.Applications
 {
+    /// <summary>
+    /// A <see cref="WebApplicationFactory{TEntryPoint}"/> that injects consumed configuration into the test web host.
+    /// </summary>
+    /// <typeparam name="TEntryPoint">The entry-point type of the application under test.</typeparam>
     public class WebApplication<TEntryPoint> : WebApplicationFactory<TEntryPoint>, IWebApplication where TEntryPoint : class
     {
+        /// <inheritdoc/>
         public List<ConfigurationEntry<object>> ConsumedConfiguration { get; set; } = new List<ConfigurationEntry<object>>();
 
+        /// <inheritdoc/>
         public virtual HttpClient CreateDefaultClient()
         {
             return base.CreateDefaultClient();
         }
 
+        /// <inheritdoc/>
         protected override void ConfigureWebHost(IWebHostBuilder builder)
         {
             base.ConfigureWebHost(builder);
 
             builder.ConfigureAppConfiguration((config) =>
             {
-                Dictionary<string, string> aggregatedConfiguration = ConsumedConfiguration
+                Dictionary<string, string?> aggregatedConfiguration = ConsumedConfiguration
                                                 .Select(ce => ce.Value.ToDictionary(ce.Key))
                                                 .SelectMany(d => d)
                                                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);

--- a/NotoriousTest.Web/Environments/WebEnvironment.cs
+++ b/NotoriousTest.Web/Environments/WebEnvironment.cs
@@ -1,4 +1,4 @@
-﻿using NotoriousTest.Web.Applications;
+using NotoriousTest.Web.Applications;
 using NotoriousTest.Web.Infrastructures;
 
 using Xunit.Sdk;
@@ -8,20 +8,23 @@ using Environment = NotoriousTest.Environments.Environment;
 namespace NotoriousTest.Web.Environments
 {
     /// <summary>
-    /// Testing environment that support Web application.
+    /// Testing environment that supports a web application infrastructure.
     /// </summary>
-    /// <typeparam name="TEntryPoint">An entrypoint to your program.cs</typeparam>
     public abstract class WebEnvironment : Environment
     {
+        /// <summary>Initializes a new instance with the given xUnit message sink.</summary>
+        /// <param name="sink">The xUnit message sink for diagnostic output.</param>
         protected WebEnvironment(IMessageSink sink) : base(sink)
         {
         }
 
+        /// <summary>Gets the registered <see cref="WebApplicationInfrastructure"/> from the environment.</summary>
         public WebApplicationInfrastructure WebApp => GetInfrastructure<WebApplicationInfrastructure>();
+
         /// <summary>
         /// Adds a web application factory to the current web environment configuration.
         /// </summary>
-        /// <param name="webApp">The web application factory instance to be added. Cannot be null.</param>
+        /// <typeparam name="TWebApp">The web application factory type to register.</typeparam>
         /// <returns>The current web environment instance with the web application factory added.</returns>
         public WebEnvironment AddWebApplication<TWebApp>() where TWebApp : IWebApplication, new()
         {

--- a/NotoriousTest.Web/Helpers/ObjectExtensions.cs
+++ b/NotoriousTest.Web/Helpers/ObjectExtensions.cs
@@ -1,16 +1,24 @@
-﻿using NotoriousTest.Web.Helpers;
-
 using System.Collections;
+
 namespace NotoriousTest.Web.Helpers
 {
+    /// <summary>
+    /// Extension methods for converting objects to flat string dictionaries suitable for configuration injection.
+    /// </summary>
     public static class ObjectExtensions
     {
-        public static Dictionary<string, string> ToDictionary(
+        /// <summary>
+        /// Flattens an object into a dictionary of string key/value pairs using colon-separated paths as keys.
+        /// </summary>
+        /// <param name="obj">The object to flatten.</param>
+        /// <param name="name">Optional prefix for all keys.</param>
+        /// <returns>A flat dictionary with colon-separated keys and nullable string values.</returns>
+        public static Dictionary<string, string?> ToDictionary(
             this object obj,
             string name = "")
         {
 
-            if (obj is Dictionary<string, string> dict)
+            if (obj is Dictionary<string, string?> dict)
             {
                 return dict.ToDictionary(
                     kvp => string.IsNullOrEmpty(name) ? kvp.Key : $"{name}:{kvp.Key}",
@@ -26,7 +34,7 @@ namespace NotoriousTest.Web.Helpers
         }
 
         private static void Flatten(
-            IDictionary<string, string> dictionary,
+            IDictionary<string, string?> dictionary,
             object? obj,
             string prefix)
         {
@@ -68,7 +76,4 @@ namespace NotoriousTest.Web.Helpers
             }
         }
     }
-
-
-
 }

--- a/NotoriousTest.Web/Infrastructures/WebApplicationInfrastructure.cs
+++ b/NotoriousTest.Web/Infrastructures/WebApplicationInfrastructure.cs
@@ -1,36 +1,59 @@
-﻿using NotoriousTest.Configuration;
+using NotoriousTest.Configuration;
 using NotoriousTest.Infrastructures;
 using NotoriousTest.Logger;
 using NotoriousTest.Web.Applications;
 namespace NotoriousTest.Web.Infrastructures
 {
+    /// <summary>
+    /// Infrastructure base class that hosts a web application factory for integration testing.
+    /// </summary>
     public abstract class WebApplicationInfrastructure : Infrastructure, IConfigurationConsumer
     {
-        public List<ConfigurationEntry<object>> ConsumedConfiguration { get; set; }
+        /// <inheritdoc/>
+        public List<ConfigurationEntry<object>> ConsumedConfiguration { get; set; } = [];
+
+        /// <summary>Gets or sets the <see cref="HttpClient"/> created from the web application factory.</summary>
         public HttpClient? HttpClient;
+
+        /// <inheritdoc/>
         public override int? Order => 999;
 
+        /// <summary>Initializes a new instance with the given context and logger.</summary>
+        /// <param name="contextId">The environment context identifier.</param>
+        /// <param name="logger">The test logger.</param>
         protected WebApplicationInfrastructure(ContextId contextId, ITestLogger logger) : base(contextId, logger)
         {
 
         }
 
     }
+
+    /// <summary>
+    /// Concrete infrastructure that creates and manages a typed web application factory.
+    /// </summary>
+    /// <typeparam name="TWebApp">The web application factory type.</typeparam>
     public class WebApplicationInfrastructure<TWebApp> : WebApplicationInfrastructure where TWebApp : IWebApplication, new()
     {
         private TWebApp _webApplicationFactory;
+
+        /// <inheritdoc/>
         public override int? Order => 999;
 
+        /// <summary>Initializes a new instance and creates the web application factory.</summary>
+        /// <param name="contextId">The environment context identifier.</param>
+        /// <param name="logger">The test logger.</param>
         public WebApplicationInfrastructure(ContextId contextId, ITestLogger logger) : base(contextId, logger)
         {
             _webApplicationFactory = new TWebApp();
         }
 
+        /// <inheritdoc/>
         public override async Task Destroy()
         {
             await _webApplicationFactory.DisposeAsync();
         }
 
+        /// <inheritdoc/>
         public override Task Initialize()
         {
             if (_webApplicationFactory is IConfigurationConsumer configurableApplication)
@@ -42,6 +65,7 @@ namespace NotoriousTest.Web.Infrastructures
             return Task.CompletedTask;
         }
 
+        /// <inheritdoc/>
         public override Task Reset()
         {
             return Task.CompletedTask;

--- a/NotoriousTest.Web/NotoriousTest.Web.csproj
+++ b/NotoriousTest.Web/NotoriousTest.Web.csproj
@@ -15,19 +15,19 @@
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+		<PackageReference Include="xunit.v3.extensibility.core" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="8.0.*" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="9.0.*" />
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" VersionOverride="10.0.*" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/NotoriousTest/Configuration/ConfigurationEntry.cs
+++ b/NotoriousTest/Configuration/ConfigurationEntry.cs
@@ -1,15 +1,26 @@
-﻿namespace NotoriousTest.Configuration
+namespace NotoriousTest.Configuration
 {
+    /// <summary>
+    /// Represents a configuration entry with a value and an optional section key.
+    /// </summary>
+    /// <typeparam name="T">The type of the configuration value.</typeparam>
     public record ConfigurationEntry<T>
     {
+        /// <summary>Gets or sets the configuration value.</summary>
         public T Value { get; set; }
+
+        /// <summary>Gets or sets the configuration key, defaulting to the type name of the value.</summary>
         public string Key { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of <see cref="ConfigurationEntry{T}"/> with the specified value and optional section.
+        /// </summary>
+        /// <param name="value">The configuration value.</param>
+        /// <param name="section">The section key. If null, the type name of <paramref name="value"/> is used.</param>
         public ConfigurationEntry(T value, string? section = null)
         {
             Value = value;
-            Key = section ?? value.GetType().Name ?? throw new ArgumentNullException(nameof(value));
+            Key = section ?? value?.GetType().Name ?? throw new ArgumentNullException(nameof(value));
         }
     };
 }
-

--- a/NotoriousTest/Configuration/IConfigurationConsumer.cs
+++ b/NotoriousTest/Configuration/IConfigurationConsumer.cs
@@ -1,7 +1,11 @@
-﻿namespace NotoriousTest.Configuration
+namespace NotoriousTest.Configuration
 {
+    /// <summary>
+    /// Indicates that a class can consume configuration entries produced by other infrastructures.
+    /// </summary>
     public interface IConfigurationConsumer
     {
+        /// <summary>Gets or sets the list of configuration entries consumed by this instance.</summary>
         List<ConfigurationEntry<object>> ConsumedConfiguration { get; set; }
     }
 }

--- a/NotoriousTest/Configuration/IConfigurationProducer.cs
+++ b/NotoriousTest/Configuration/IConfigurationProducer.cs
@@ -1,4 +1,4 @@
-﻿namespace NotoriousTest.Configuration
+namespace NotoriousTest.Configuration
 {
     /// <summary>
     /// Make a class able to produce or consume configuration
@@ -6,11 +6,12 @@
     /// <typeparam name="T">Configuration type.</typeparam>
     public interface IConfigurationProducer<T> : IConfigurationProducer
     {
+        /// <summary>Gets the list of typed configuration entries produced by this instance.</summary>
         new List<ConfigurationEntry<T>> OutputConfiguration { get; }
 
         List<ConfigurationEntry<object>> IConfigurationProducer.OutputConfiguration
             => OutputConfiguration
-            .Select(ce => new ConfigurationEntry<object>(ce.Value, ce.Key))
+            .Select(ce => new ConfigurationEntry<object>(ce.Value!, ce.Key))
             .ToList();
 
         /// <summary>
@@ -21,6 +22,9 @@
         void AddEntry(string key, T value);
     }
 
+    /// <summary>
+    /// Indicates that a class can produce configuration entries for consumption by other infrastructures.
+    /// </summary>
     public interface IConfigurationProducer
     {
         /// <summary>

--- a/NotoriousTest/ContextId.cs
+++ b/NotoriousTest/ContextId.cs
@@ -1,8 +1,15 @@
-﻿namespace NotoriousTest
+namespace NotoriousTest
 {
+    /// <summary>
+    /// A strongly-typed wrapper around <see cref="Guid"/> used to uniquely identify a test context.
+    /// </summary>
+    /// <param name="Value">The underlying <see cref="Guid"/> value.</param>
     public record ContextId(Guid Value)
     {
+        /// <summary>Implicitly converts a <see cref="ContextId"/> to its underlying <see cref="Guid"/>.</summary>
         public static implicit operator Guid(ContextId wrapper) => wrapper.Value;
+
+        /// <summary>Implicitly converts a <see cref="Guid"/> to a <see cref="ContextId"/>.</summary>
         public static implicit operator ContextId(Guid guid) => new(guid);
     }
 }

--- a/NotoriousTest/Environments/Environment.cs
+++ b/NotoriousTest/Environments/Environment.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
 
 using NotoriousTest.Configuration;
 using NotoriousTest.Exceptions;
@@ -21,8 +21,10 @@ namespace NotoriousTest.Environments
         /// Gets the unique identifier for the environment instance.
         /// </summary>
         public ContextId EnvironmentId { get; private set; } = Guid.NewGuid();
-        protected IServiceProvider ServiceProvider { get; private set; }
-        private IServiceCollection _serviceCollection;
+
+        /// <summary>Gets the service provider built from the configured infrastructure services.</summary>
+        protected IServiceProvider? ServiceProvider { get; private set; }
+        private IServiceCollection? _serviceCollection;
 
         /// <summary>
         /// Gets the collection of infrastructure components associated with this instance.
@@ -30,6 +32,8 @@ namespace NotoriousTest.Environments
         private List<Infrastructure> _infrastructures = [];
         private readonly IMessageSink _sink;
 
+        /// <summary>Initializes a new instance of <see cref="Environment"/> with the specified message sink.</summary>
+        /// <param name="sink">The xUnit message sink used for diagnostic output.</param>
         protected Environment(IMessageSink sink)
         {
             _sink = sink;
@@ -63,10 +67,10 @@ namespace NotoriousTest.Environments
         /// <returns></returns>
         public virtual async Task ConfigureInfrastructureServices(IServiceCollection collection)
         {
-            _serviceCollection.AddSingleton(EnvironmentId);
-            _serviceCollection.AddSingleton<ITestSettingsProvider, TestSettingsProvider>();
-            _serviceCollection.AddSingleton(_sink);
-            _serviceCollection.AddSingleton<ITestLogger, TestLogger>();
+            collection.AddSingleton(EnvironmentId);
+            collection.AddSingleton<ITestSettingsProvider, TestSettingsProvider>();
+            collection.AddSingleton(_sink);
+            collection.AddSingleton<ITestLogger, TestLogger>();
         }
 
         /// <summary>
@@ -94,7 +98,7 @@ namespace NotoriousTest.Environments
         /// Add an infrastructure within environment.
         /// </summary>
         public Environment AddInfrastructure<T>() where T : Infrastructure
-            => AddInfrastructure(ActivatorUtilities.CreateInstance<T>(ServiceProvider));
+            => AddInfrastructure(ActivatorUtilities.CreateInstance<T>(ServiceProvider!));
 
         /// <summary>
         /// Add an infrastructure within environment.
@@ -106,6 +110,7 @@ namespace NotoriousTest.Environments
             return this;
         }
 
+        /// <summary>Initializes all registered infrastructures in order, injecting consumed configuration where needed.</summary>
         public virtual async Task Initialize()
         {
             foreach (Infrastructure infra in _infrastructures.OrderBy(i => i.Order))
@@ -119,6 +124,7 @@ namespace NotoriousTest.Environments
             }
         }
 
+        /// <summary>Resets all infrastructures that have <see cref="IInfrastructure.AutoReset"/> enabled, in order.</summary>
         public virtual async Task Reset()
         {
             foreach (Infrastructure infrastructure in _infrastructures.OrderBy(pi => pi.Order))
@@ -127,6 +133,7 @@ namespace NotoriousTest.Environments
             }
         }
 
+        /// <summary>Destroys all registered infrastructures in order.</summary>
         public virtual async Task Destroy()
         {
             foreach (Infrastructure infra in _infrastructures.OrderBy(i => i.Order))
@@ -139,7 +146,7 @@ namespace NotoriousTest.Environments
         {
             return _infrastructures
                     .Where(i => i is IConfigurationProducer)
-                    .SelectMany(i => (i as IConfigurationProducer).OutputConfiguration)
+                    .SelectMany(i => ((IConfigurationProducer)i).OutputConfiguration)
                     .ToList();
         }
     }

--- a/NotoriousTest/Exceptions/InfrastructureNotFoundException.cs
+++ b/NotoriousTest/Exceptions/InfrastructureNotFoundException.cs
@@ -1,15 +1,24 @@
-﻿namespace NotoriousTest.Exceptions
+namespace NotoriousTest.Exceptions
 {
+    /// <summary>
+    /// Exception thrown when a requested infrastructure is not found within an environment.
+    /// </summary>
     public class InfrastructureNotFoundException : Exception
     {
+        /// <summary>Initializes a new instance of <see cref="InfrastructureNotFoundException"/>.</summary>
         public InfrastructureNotFoundException()
         {
         }
 
+        /// <summary>Initializes a new instance of <see cref="InfrastructureNotFoundException"/> with a message.</summary>
+        /// <param name="message">The error message.</param>
         public InfrastructureNotFoundException(string? message) : base(message)
         {
         }
 
+        /// <summary>Initializes a new instance of <see cref="InfrastructureNotFoundException"/> with a message and inner exception.</summary>
+        /// <param name="message">The error message.</param>
+        /// <param name="innerException">The inner exception.</param>
         public InfrastructureNotFoundException(string? message, Exception? innerException) : base(message, innerException)
         {
         }

--- a/NotoriousTest/Extensions/IInfrastructureExtension.cs
+++ b/NotoriousTest/Extensions/IInfrastructureExtension.cs
@@ -1,5 +1,8 @@
-﻿using NotoriousTest.Infrastructures;
+using NotoriousTest.Infrastructures;
 
+/// <summary>
+/// Allows extending infrastructure lifecycle with custom hooks for initialize, reset, and destroy events.
+/// </summary>
 public interface IInfrastructureExtension
 {
     /// <summary>
@@ -33,6 +36,10 @@ public interface IInfrastructureExtension
     Task OnAfterDestroy(IInfrastructure infrastructure) => Task.CompletedTask;
 }
 
+/// <summary>
+/// Strongly-typed variant of <see cref="IInfrastructureExtension"/> that receives a specific infrastructure type.
+/// </summary>
+/// <typeparam name="T">The concrete infrastructure type this extension handles.</typeparam>
 public interface IInfrastructureExtension<T> : IInfrastructureExtension where T : IInfrastructure
 {
     Task IInfrastructureExtension.OnBeforeInitialize(IInfrastructure infrastructure)
@@ -56,30 +63,30 @@ public interface IInfrastructureExtension<T> : IInfrastructureExtension where T 
     /// <summary>
     /// Called before the infrastructure is initialized.
     /// </summary>
-    new Task OnBeforeInitialize(T infrastructure) => Task.CompletedTask;
+    Task OnBeforeInitialize(T infrastructure) => Task.CompletedTask;
 
     /// <summary>
     /// Called after the infrastructure is initialized.
     /// </summary>
-    new Task OnAfterInitialize(T infrastructure) => Task.CompletedTask;
+    Task OnAfterInitialize(T infrastructure) => Task.CompletedTask;
 
     /// <summary>
     /// Called before the infrastructure is reset.
     /// </summary>
-    new Task OnBeforeReset(T infrastructure) => Task.CompletedTask;
+    Task OnBeforeReset(T infrastructure) => Task.CompletedTask;
 
     /// <summary>
     /// Called after the infrastructure is reset.
     /// </summary>
-    new Task OnAfterReset(T infrastructure) => Task.CompletedTask;
+    Task OnAfterReset(T infrastructure) => Task.CompletedTask;
 
     /// <summary>
     /// Called before the infrastructure is destroyed.
     /// </summary>
-    new Task OnBeforeDestroy(T infrastructure) => Task.CompletedTask;
+    Task OnBeforeDestroy(T infrastructure) => Task.CompletedTask;
 
     /// <summary>
     /// Called after the infrastructure is destroyed.
     /// </summary>
-    new Task OnAfterDestroy(T infrastructure) => Task.CompletedTask;
+    Task OnAfterDestroy(T infrastructure) => Task.CompletedTask;
 }

--- a/NotoriousTest/Extensions/OutputConfigurationExtension.cs
+++ b/NotoriousTest/Extensions/OutputConfigurationExtension.cs
@@ -1,15 +1,24 @@
-﻿using NotoriousTest.Configuration;
+using NotoriousTest.Configuration;
 
 namespace NotoriousTest.Extensions;
 
-// Extension OutputConfiguration
+/// <summary>
+/// Infrastructure extension that collects typed configuration entries to expose as output configuration.
+/// </summary>
+/// <typeparam name="TOutputConfiguration">The type of configuration value produced.</typeparam>
 public class OutputConfigurationExtension<TOutputConfiguration> : IInfrastructureExtension
 {
+    /// <summary>Gets the list of typed configuration entries collected by this extension.</summary>
     public List<ConfigurationEntry<TOutputConfiguration>> OutputConfiguration { get; } = new();
 
+    /// <summary>Adds a configuration entry with the specified key and value.</summary>
+    /// <param name="key">The configuration key.</param>
+    /// <param name="value">The configuration value.</param>
     public void AddEntry(string key, TOutputConfiguration value)
         => OutputConfiguration.Add(new ConfigurationEntry<TOutputConfiguration>(value, key));
 
+    /// <summary>Adds a configuration entry using the type name of the value as the key.</summary>
+    /// <param name="value">The configuration value.</param>
     public void AddEntry(TOutputConfiguration value)
         => OutputConfiguration.Add(new ConfigurationEntry<TOutputConfiguration>(value, value!.GetType().Name));
 }

--- a/NotoriousTest/Extensions/SettingsExtension.cs
+++ b/NotoriousTest/Extensions/SettingsExtension.cs
@@ -1,23 +1,33 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 
 using NotoriousTest.Infrastructures;
 using NotoriousTest.Settings;
 
 namespace NotoriousTest.Extensions;
 
+/// <summary>
+/// Infrastructure extension that binds a settings section from <c>testsettings.json</c> to a typed settings object.
+/// </summary>
+/// <typeparam name="TSettings">The settings type to bind. Must have a parameterless constructor.</typeparam>
 public class SettingsExtension<TSettings> : IInfrastructureExtension
     where TSettings : class, new()
 {
+    /// <summary>Gets the bound settings object populated before infrastructure initialization.</summary>
     public TSettings Settings { get; private set; } = new();
 
+    /// <summary>Gets the configuration section name to bind. Defaults to the infrastructure type name when null.</summary>
     protected string? SectionName { get; init; }
     private ITestSettingsProvider _settingsProvider;
 
+    /// <summary>Initializes a new instance with the given settings provider.</summary>
+    /// <param name="settingsProvider">The provider used to locate and load test settings.</param>
     public SettingsExtension(ITestSettingsProvider settingsProvider)
     {
         _settingsProvider = settingsProvider ?? throw new ArgumentNullException(nameof(settingsProvider));
     }
 
+    /// <summary>Binds the settings section to <see cref="Settings"/> before the infrastructure initializes.</summary>
+    /// <param name="infrastructure">The infrastructure being initialized.</param>
     public Task OnBeforeInitialize(IInfrastructure infrastructure)
     {
         var configuration = _settingsProvider.Find();

--- a/NotoriousTest/Infrastructures/IInfrastructure.cs
+++ b/NotoriousTest/Infrastructures/IInfrastructure.cs
@@ -1,13 +1,26 @@
-﻿namespace NotoriousTest.Infrastructures
+namespace NotoriousTest.Infrastructures
 {
+    /// <summary>
+    /// Defines the contract for a test infrastructure component managed by an environment.
+    /// </summary>
     public interface IInfrastructure
     {
+        /// <summary>Gets or sets whether the infrastructure is automatically reset between tests.</summary>
         bool AutoReset { get; set; }
+
+        /// <summary>Gets or sets the context identifier linking this infrastructure to its environment.</summary>
         ContextId ContextId { get; set; }
+
+        /// <summary>Gets the initialization order of this infrastructure; lower values initialize first.</summary>
         int? Order { get; }
 
+        /// <summary>Destroys the infrastructure and releases all associated resources.</summary>
         Task Destroy();
+
+        /// <summary>Initializes the infrastructure.</summary>
         Task Initialize();
+
+        /// <summary>Resets the infrastructure to a clean state between tests.</summary>
         Task Reset();
     }
 }

--- a/NotoriousTest/Infrastructures/Infrastructure.cs
+++ b/NotoriousTest/Infrastructures/Infrastructure.cs
@@ -1,4 +1,4 @@
-﻿using NotoriousTest.Configuration;
+using NotoriousTest.Configuration;
 using NotoriousTest.Extensions;
 using NotoriousTest.Logger;
 
@@ -6,17 +6,29 @@ using System.Diagnostics;
 
 namespace NotoriousTest.Infrastructures;
 
-
+/// <summary>
+/// Infrastructure base class that also produces typed configuration entries.
+/// </summary>
+/// <typeparam name="TOutputConfiguration">The type of configuration value produced by this infrastructure.</typeparam>
 public abstract class Infrastructure<TOutputConfiguration> : Infrastructure, IConfigurationProducer<TOutputConfiguration>
 {
+    /// <summary>Gets the list of typed configuration entries produced by this infrastructure.</summary>
     public List<ConfigurationEntry<TOutputConfiguration>> OutputConfiguration => OutputConfigurationExtension.OutputConfiguration;
 
+    /// <summary>Gets the extension managing output configuration entries.</summary>
     protected OutputConfigurationExtension<TOutputConfiguration> OutputConfigurationExtension { get; private set; }
+
+    /// <summary>Initializes a new instance with the given context and logger.</summary>
+    /// <param name="contextId">The environment context identifier.</param>
+    /// <param name="logger">The test logger.</param>
     protected Infrastructure(ContextId contextId, ITestLogger logger) : base(contextId, logger)
     {
         OutputConfigurationExtension = EnsureExtension(new OutputConfigurationExtension<TOutputConfiguration>());
     }
 
+    /// <summary>Adds a configuration entry with the specified key and value.</summary>
+    /// <param name="key">The configuration key.</param>
+    /// <param name="value">The configuration value.</param>
     public void AddEntry(string key, TOutputConfiguration value) => OutputConfigurationExtension.AddEntry(key, value);
 }
 
@@ -34,18 +46,27 @@ public abstract class Infrastructure : IAsyncDisposable, IInfrastructure
     ///<inheritdoc/>
     public ContextId ContextId { get; set; }
 
+    /// <summary>Gets the logger used to emit diagnostic messages during infrastructure lifecycle.</summary>
     protected readonly ITestLogger Logger;
 
     private readonly List<IInfrastructureExtension> _extensions = new();
 
+    /// <summary>Initializes a new instance with the given context and logger.</summary>
+    /// <param name="contextId">The environment context identifier.</param>
+    /// <param name="logger">The test logger.</param>
     public Infrastructure(ContextId contextId, ITestLogger logger)
     {
         ContextId = contextId;
         Logger = logger;
     }
 
+    ///<inheritdoc/>
     public abstract Task Initialize();
+
+    ///<inheritdoc/>
     public abstract Task Reset();
+
+    ///<inheritdoc/>
     public abstract Task Destroy();
 
     async ValueTask IAsyncDisposable.DisposeAsync()

--- a/NotoriousTest/IntegrationTest.cs
+++ b/NotoriousTest/IntegrationTest.cs
@@ -1,21 +1,30 @@
-﻿using Xunit;
+using Xunit;
 
 namespace NotoriousTest
 {
+    /// <summary>
+    /// Base class for integration tests that use a shared xUnit class fixture environment.
+    /// </summary>
+    /// <typeparam name="T">The environment type, must inherit from <see cref="Environments.Environment"/>.</typeparam>
     public abstract class IntegrationTest<T> : IClassFixture<T>, IAsyncLifetime where T : Environments.Environment
     {
+        /// <summary>Gets the current test environment shared across tests in the class.</summary>
         protected readonly T CurrentEnvironment;
 
+        /// <summary>Initializes a new instance with the shared environment provided by xUnit.</summary>
+        /// <param name="environment">The shared test environment instance.</param>
         public IntegrationTest(T environment)
         {
             // Called before each tests
             CurrentEnvironment = environment;
         }
 
+        /// <summary>Called by xUnit before each test method; override to add per-test setup.</summary>
         public async ValueTask InitializeAsync()
         {
         }
 
+        /// <summary>Resets the environment after each test method.</summary>
         public async ValueTask DisposeAsync()
         {
             await CurrentEnvironment.Reset();

--- a/NotoriousTest/Logger/ITestLogger.cs
+++ b/NotoriousTest/Logger/ITestLogger.cs
@@ -1,7 +1,12 @@
-﻿namespace NotoriousTest.Logger
+namespace NotoriousTest.Logger
 {
+    /// <summary>
+    /// Provides a mechanism for emitting diagnostic log messages during test infrastructure lifecycle.
+    /// </summary>
     public interface ITestLogger
     {
+        /// <summary>Logs a diagnostic message.</summary>
+        /// <param name="message">The message to log.</param>
         void Log(string message);
     }
 }

--- a/NotoriousTest/Logger/TestLogger.cs
+++ b/NotoriousTest/Logger/TestLogger.cs
@@ -1,19 +1,26 @@
-﻿using Xunit.Sdk;
+using Xunit.Sdk;
 using Xunit.v3;
 
 namespace NotoriousTest.Logger
 {
+    /// <summary>
+    /// xUnit implementation of <see cref="ITestLogger"/> that emits messages via <see cref="IMessageSink"/>.
+    /// </summary>
     public class TestLogger : ITestLogger
     {
         private readonly IMessageSink _sink;
         private readonly ContextId _contextId;
 
+        /// <summary>Initializes a new instance with the given message sink and context identifier.</summary>
+        /// <param name="sink">The xUnit message sink used to emit diagnostic messages.</param>
+        /// <param name="contextId">The context identifier included in each log message.</param>
         public TestLogger(IMessageSink sink, ContextId contextId)
         {
             _sink = sink;
             this._contextId = contextId;
         }
 
+        /// <inheritdoc/>
         public void Log(string message)
         {
             _sink.OnMessage(new DiagnosticMessage($"[NotoriousTest][{_contextId.Value.ToString()}]{message}"));

--- a/NotoriousTest/NotoriousTest.csproj
+++ b/NotoriousTest/NotoriousTest.csproj
@@ -17,13 +17,13 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-		<PackageReference Include="xunit.v3.extensibility.core" Version="3.2.2" />
+		<PackageReference Include="Microsoft.Extensions.Configuration" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
+		<PackageReference Include="xunit.v3.extensibility.core" />
 	</ItemGroup>
 	<ItemGroup>
 		<None Include="..\icon.png" Pack="true" PackagePath="" Visible="False" />

--- a/NotoriousTest/Settings/ITestSettingsProvider.cs
+++ b/NotoriousTest/Settings/ITestSettingsProvider.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 
 namespace NotoriousTest.Settings
 {
+    /// <summary>
+    /// Provides access to test settings configuration.
+    /// </summary>
     public interface ITestSettingsProvider
     {
+        /// <summary>Finds and returns the test settings configuration.</summary>
         IConfiguration Find();
     }
 }

--- a/NotoriousTest/Settings/TestSettingsProvider.cs
+++ b/NotoriousTest/Settings/TestSettingsProvider.cs
@@ -1,10 +1,10 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
 
 namespace NotoriousTest.Settings
 {
     internal class TestSettingsProvider : ITestSettingsProvider
     {
-        private IConfiguration _cache;
+        private IConfiguration? _cache;
         public IConfiguration Find()
         {
             if (_cache == null)

--- a/Samples/NotoriousTests.InfrastructuresSamples.TestWebApp/NotoriousTests.InfrastructuresSamples.TestWebApp.csproj
+++ b/Samples/NotoriousTests.InfrastructuresSamples.TestWebApp/NotoriousTests.InfrastructuresSamples.TestWebApp.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
 </Project>

--- a/Samples/NotoriousTests.InfrastructuresSamples/NotoriousTests.InfrastructuresSamples.csproj
+++ b/Samples/NotoriousTests.InfrastructuresSamples/NotoriousTests.InfrastructuresSamples.csproj
@@ -8,14 +8,14 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-		<PackageReference Include="Respawn" Version="7.0.0" />
-		<PackageReference Include="xunit.v3" Version="3.2.2" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" />
+		<PackageReference Include="Respawn" />
+		<PackageReference Include="xunit.v3" />
+		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="8.0.1">
+		<PackageReference Include="coverlet.collector">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>

--- a/Samples/NotoriousTests.InfrastructuresSamples/SampleTests.cs
+++ b/Samples/NotoriousTests.InfrastructuresSamples/SampleTests.cs
@@ -22,8 +22,8 @@ namespace NotoriousTests.InfrastructuresSamples
         {
             // You can access an infrastructure directly from the CurrentEnvironment property of the test class.
             // This is useful to access the database connection for example.
-            HttpClient client = CurrentEnvironment.WebApp.HttpClient;
-            HttpResponseMessage response = await client.PostAsync("users", null);
+            HttpClient client = CurrentEnvironment.WebApp.HttpClient!;
+            HttpResponseMessage response = await client.PostAsync("users", null, TestContext.Current.CancellationToken);
 
             // Then assert that the database is in the expected state
             Assert.True(response.IsSuccessStatusCode);
@@ -36,7 +36,7 @@ namespace NotoriousTests.InfrastructuresSamples
                 using (DbCommand command = sql.CreateCommand())
                 {
                     command.CommandText = "SELECT COUNT(*) FROM Users";
-                    int count = (int)await command.ExecuteScalarAsync(TestContext.Current.CancellationToken);
+                    int count = (int)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken))!;
                     Assert.Equal(1, count);
                 }
             }


### PR DESCRIPTION
## Summary

- **CPM compatibility**: Removed inline `Version` attributes from all `PackageReference` elements across all `.csproj` files to align with the repo's central `Directory.Packages.props`
- **Nullable warnings** (CS8618/CS8602/CS8604/CS8620/CS8619/CS8625): Made lazily-initialized fields nullable, used `default!` for `init`-only container properties, fixed `Dictionary<string, string?>` nullability mismatches in `ObjectExtensions` and `WebApplication`
- **CS0109**: Removed unnecessary `new` keywords from `IInfrastructureExtension<T>` typed overloads
- **CS1591**: Added XML documentation comments to all public types and members in `NotoriousTest` and `NotoriousTest.Web`
- **CS1711/CS1572**: Removed incorrect `<typeparam>`/`<param>` tags from `WebEnvironment` XML docs
- **CS0618**: Suppressed with `#pragma warning disable` for obsolete `MsSqlBuilder()`/`PostgreSqlBuilder()` parameterless constructors — Testcontainers v4 API migration is a separate concern
- **TreatWarningsAsErrors**: Added `Directory.Build.props` at the worktree root that imports the repo-root props and sets `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
- **xUnit1051**: Passed `CancellationToken` to `PostAsync` in `SampleTests`

## Test plan

- [ ] Build succeeds with 0 warnings and 0 errors: `dotnet build`
- [ ] Unit tests pass: `dotnet test NotoriousTest.UnitTests`
- [ ] No new nullable warnings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)