### PR TITLE
tech: migrate all netstandard2.1 libraries to net8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,6 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <VersionPrefix>4.1.1</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
   </PropertyGroup>
 </Project>

--- a/NotoriousTest.Core/NotoriousTest.Core.csproj
+++ b/NotoriousTest.Core/NotoriousTest.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Description>Core components of NotoriousTest.</Description>
 		<PackageId>NotoriousTest.Core</PackageId>
 		<IsPackable>true</IsPackable>

--- a/NotoriousTest.Database/NotoriousTest.Database.csproj
+++ b/NotoriousTest.Database/NotoriousTest.Database.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Description>A Database integration with NotoriousTest.</Description>
 		<PackageId>NotoriousTest.Database</PackageId>
 		<IsPackable>true</IsPackable>

--- a/NotoriousTest.MSTest/NotoriousTest.MSTest.csproj
+++ b/NotoriousTest.MSTest/NotoriousTest.MSTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Description>MSTest integration for Notorious Test.</Description>
 		<PackageId>NotoriousTest.MSTest</PackageId>
 		<IsPackable>true</IsPackable>

--- a/NotoriousTest.Runtime/NotoriousTest.Runtime.csproj
+++ b/NotoriousTest.Runtime/NotoriousTest.Runtime.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 	<ItemGroup>

--- a/NotoriousTest.SqlLiteRegistry/NotoriousTest.SqlLiteRegistry.csproj
+++ b/NotoriousTest.SqlLiteRegistry/NotoriousTest.SqlLiteRegistry.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/NotoriousTest.SqlServer/NotoriousTest.SqlServer.csproj
+++ b/NotoriousTest.SqlServer/NotoriousTest.SqlServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Description>A SqlServer integration with NotoriousTest.</Description>
 		<PackageId>NotoriousTest.SqlServer</PackageId>
 		<IsPackable>true</IsPackable>

--- a/NotoriousTest.Sqlite/NotoriousTest.Sqlite.csproj
+++ b/NotoriousTest.Sqlite/NotoriousTest.Sqlite.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Description>A Sqlite integration with NotoriousTest.</Description>
 		<PackageId>NotoriousTest.PostgreSql</PackageId>
 		<IsPackable>true</IsPackable>

--- a/NotoriousTest.TestContainers/NotoriousTest.TestContainers.csproj
+++ b/NotoriousTest.TestContainers/NotoriousTest.TestContainers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Description>A TestContainers integration with NotoriousTest.</Description>
 		<PackageId>NotoriousTest.TestContainers</PackageId>
 		<IsPackable>true</IsPackable>

--- a/NotoriousTest.TestSettings/NotoriousTest.TestSettings.csproj
+++ b/NotoriousTest.TestSettings/NotoriousTest.TestSettings.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/NotoriousTest.Watchdog/NotoriousTest.Watchdog.csproj
+++ b/NotoriousTest.Watchdog/NotoriousTest.Watchdog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/NotoriousTest.XUnit/NotoriousTest.XUnit.csproj
+++ b/NotoriousTest.XUnit/NotoriousTest.XUnit.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Description>XUnit integration for Notorious Test.</Description>
 		<PackageId>NotoriousTest.XUnit</PackageId>
 		<IsPackable>true</IsPackable>

--- a/NotoriousTest/NotoriousTest.csproj
+++ b/NotoriousTest/NotoriousTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Description>A simple way to handle integration tests environment, with complete isolation of every tests.</Description>
 		<PackageId>NotoriousTest</PackageId>
 		<IsPackable>true</IsPackable>


### PR DESCRIPTION
## Summary

- Migrated all 12 library projects from `netstandard2.1` to `net8.0`
- All projects: `NotoriousTest`, `NotoriousTest.Core`, `NotoriousTest.Runtime`, `NotoriousTest.Sqlite`, `NotoriousTest.MSTest`, `NotoriousTest.XUnit`, `NotoriousTest.Database`, `NotoriousTest.SqlServer`, `NotoriousTest.TestContainers`, `NotoriousTest.TestSettings`, `NotoriousTest.SqlLiteRegistry`, `NotoriousTest.Watchdog`

## Test plan

- [x] `dotnet restore` — successful
- [x] `dotnet build` — successful (57 unit tests compile and pass)
- [x] Unit tests (57/57 pass)
- [ ] Samples/integration tests require DoggyDog infrastructure — unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)